### PR TITLE
Improve sign in logic when no `well_known['m.homeserver']` is returned

### DIFF
--- a/lib/Auth.js
+++ b/lib/Auth.js
@@ -40,19 +40,24 @@ function useAuthProvider() {
     const signin = async (username, password, homeserver) => {
         const matrixAuthenticationResponse = await getAuthenticationProvider('matrix').signin(username, password, homeserver);
 
-        if (!matrixAuthenticationResponse.well_known) {
-            matrixAuthenticationResponse.well_known = { 'm.homeserver': { base_url: 'https://' + matrixAuthenticationResponse.home_server + '/' } };
+        window.localStorage.setItem('medienhaus_access_token', matrixAuthenticationResponse.access_token);
+
+        if (matrixAuthenticationResponse.well_known?.['m.homeserver']) {
+            // Set  window.localStorage items for medienhaus/
+            window.localStorage.setItem('medienhaus_hs_url', matrixAuthenticationResponse.well_known['m.homeserver'].base_url);
+            // Set window.localStorage items for the Element client to automatically be logged-in
+            window.localStorage.setItem('mx_hs_url', matrixAuthenticationResponse.well_known['m.homeserver'].base_url);
+        } else {
+            window.localStorage.setItem('medienhaus_hs_url', getConfig().publicRuntimeConfig.authProviders.matrix?.base_url);
+            window.localStorage.setItem('mx_hs_url', getConfig().publicRuntimeConfig.authProviders.matrix?.base_url);
         }
 
-        // Set window.localStorage items for medienhaus/
-        window.localStorage.setItem('medienhaus_access_token', matrixAuthenticationResponse.access_token);
-        window.localStorage.setItem('medienhaus_hs_url', matrixAuthenticationResponse.well_known['m.homeserver'].base_url);
+        // Set other window.localStorage items for medienhaus/
         window.localStorage.setItem('medienhaus_user_id', matrixAuthenticationResponse.user_id);
 
-        // Set window.localStorage items for the Element client to automatically be logged-in
+        // Set other window.localStorage items for the Element client to automatically be logged-in
         window.localStorage.setItem('mx_access_token', matrixAuthenticationResponse.access_token);
         window.localStorage.setItem('mx_home_server', matrixAuthenticationResponse.home_server);
-        window.localStorage.setItem('mx_hs_url', matrixAuthenticationResponse.well_known['m.homeserver'].base_url);
         window.localStorage.setItem('mx_user_id', matrixAuthenticationResponse.user_id);
         window.localStorage.setItem('mx_device_id', matrixAuthenticationResponse.device_id);
 


### PR DESCRIPTION
sets the localstorage items from `next.config.js` instead of adding the key `m.homeserver` to the object.