### PR TITLE
Use the element home screen to create new chats

### DIFF
--- a/pages/chat/[[...roomId]].js
+++ b/pages/chat/[[...roomId]].js
@@ -173,11 +173,15 @@ export default function RoomId() {
                 </details>
                 <br />
             </IframeLayout.Sidebar>
-            { roomId && (
-                <IframeLayout.IframeWrapper>
-                    <iframe src={`${getConfig().publicRuntimeConfig.chat.pathToElement}/#/room/${roomId}`} ref={iframe} />
-                </IframeLayout.IframeWrapper>
-            ) }
+
+            <IframeLayout.IframeWrapper>
+                <iframe src={roomId ?
+                    `${getConfig().publicRuntimeConfig.chat.pathToElement}/#/room/${roomId}`
+                    : `${getConfig().publicRuntimeConfig.chat.pathToElement}/#/home`
+                }
+                ref={iframe} />
+            </IframeLayout.IframeWrapper>
+
         </>
     );
 }


### PR DESCRIPTION
Display elements home screen by default when no chat is selected as a first and simple solution to create chats.