### PR TITLE
Move service submenu actions into their own directory

### DIFF
--- a/components/UI/ServiceSubmenu.js
+++ b/components/UI/ServiceSubmenu.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { cloneElement, useState } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 import _ from 'lodash';
@@ -45,7 +45,10 @@ export function ServiceSubmenu({ title, icon, subheadline, items }) {
 
     const handleMenuToggle = () => { setIsOpen(!isOpen); setValue(''); };
 
-    const ActionComponent = value && _.get(_.find(items, { value: value }), 'actionComponentToRender');
+    // We clone the passed in React element to add the callback function prop to it:
+    const ActionComponent = value && cloneElement(_.get(_.find(items, { value: value }), 'actionComponentToRender'), {
+        callbackDone: handleMenuToggle,
+    });
 
     return (
         <>
@@ -67,7 +70,7 @@ export function ServiceSubmenu({ title, icon, subheadline, items }) {
                             <option key={value} value={value}>{ label }</option>
                         )) }
                     </select>
-                    { value && <ActionComponent callbackDone={handleMenuToggle} /> }
+                    { value && ActionComponent }
                 </Submenu>
             ) }
         </>

--- a/pages/etherpad/[[...roomId]].js
+++ b/pages/etherpad/[[...roomId]].js
@@ -13,10 +13,13 @@ import { ServiceSubmenu } from '../../components/UI/ServiceSubmenu';
 import BinIcon from '../../assets/icons/bin.svg';
 import ClipboardIcon from '../../assets/icons/clipboard.svg';
 import { ServiceTable } from '../../components/UI/ServiceTable';
-import Form from '../../components/UI/Form';
 import LoadingSpinnerInline from '../../components/UI/LoadingSpinnerInline';
 import LoadingSpinner from '../../components/UI/LoadingSpinner';
 import logger from '../../lib/Logging';
+import CreateAnonymousPad from './actions/CreateAnonymousPad';
+import AddExistingPad from './actions/AddExistingPad';
+import CreateAuthoredPad from './actions/CreateAuthoredPad';
+import CreatePasswordPad from './actions/CreatePasswordPad';
 
 export default function Etherpad() {
     const auth = useAuth();
@@ -172,132 +175,11 @@ export default function Etherpad() {
         return room;
     }, [auth, matrix, matrixClient, etherpad]);
 
-    const ActionNewAnonymousPad = ({ callbackDone }) => {
-        const [padName, setPadName] = useState('');
-        const [isLoading, setIsLoading] = useState(false);
-
-        const createAnonymousPad = async () => {
-            setIsLoading(true);
-            let string = '';
-            const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_';
-            const charactersLength = characters.length;
-            for (let i = 0; i < 20; i++) {
-                string += characters.charAt(Math.floor(Math.random() * charactersLength));
-            }
-            const link = getConfig().publicRuntimeConfig.authProviders.etherpad.baseUrl + '/' + string;
-            const roomId = await createWriteRoom(link, padName);
-            router.push(`/${getConfig().publicRuntimeConfig.authProviders.etherpad.path}/${roomId}`);
-
-            callbackDone && callbackDone();
-            setIsLoading(false);
-            setPadName('');
-        };
-
-        return (
-            <Form onSubmit={(e) => { e.preventDefault(); createAnonymousPad(padName); }}>
-                <input type="text" placeholder={t('Pad name')} value={padName} onChange={(e) => setPadName(e.target.value)} />
-                <button type="submit" disabled={!padName}>{ isLoading ? <LoadingSpinnerInline inverted /> : t('Create pad') }</button>
-            </Form>
-        );
-    };
-
-    const ActionExistingPad = ({ callbackDone }) => {
-        const [padName, setPadName] = useState('');
-        const [padLink, setPadLink] = useState('');
-        const [validLink, setValidLink] = useState(false);
-        const [isLoading, setIsLoading] = useState(false);
-
-        const validatePadUrl = (e) => {
-            if (e.target.value.includes(getConfig().publicRuntimeConfig.authProviders.etherpad.baseUrl)) setValidLink(true);
-            else setValidLink(false);
-            setPadLink(e.target.value);
-        };
-
-        const handleExistingPadSubmit = async () => {
-            const apiUrl = padLink.replace('/p/', '/mypads/api/pad/');
-            const checkForPasswordProtection = await etherpad.checkPadForPassword(apiUrl);
-            setIsLoading(true);
-            const roomId = await createWriteRoom(padLink, padName);
-            router.push(`/${getConfig().publicRuntimeConfig.authProviders.etherpad.path}/${roomId}`);
-
-            callbackDone && callbackDone();
-            setPadLink('');
-            setIsLoading(false);
-        };
-
-        return (
-            <Form onSubmit={(e) => { e.preventDefault(); handleExistingPadSubmit(); }}>
-                <input type="text" placeholder={t('Pad name')} value={padName} onChange={(e) => setPadName(e.target.value)} />
-                <input type="text" placeholder={t('Link to pad')} value={padLink} onChange={validatePadUrl} />
-                { !validLink && padLink && (
-                    <ErrorMessage>
-                        { t('Make sure your link includes "{{url}}"', { url: getConfig().publicRuntimeConfig.authProviders.etherpad.baseUrl }) }
-                    </ErrorMessage>
-                ) }
-                <button type="submit" disabled={!padName || !padLink || !validLink}>{ isLoading ? <LoadingSpinnerInline inverted /> : t('Add pad') }</button>
-            </Form>);
-    };
-
-    const ActionPasswordPad = ({ callbackDone }) => {
-        const [padName, setPadName] = useState('');
-        const [password, setPassword] = useState('');
-        const [validatePassword, setValidatePassword] = useState('');
-        const [isLoading, setIsLoading] = useState(false);
-
-        const createPasswordPad = async () => {
-            setIsLoading(true);
-            const padId = await etherpad.createPad(padName, 'private', password);
-            const link = getConfig().publicRuntimeConfig.authProviders.etherpad.baseUrl + '/' + padId;
-            const roomId = await createWriteRoom(link, padName);
-            router.push(`/${getConfig().publicRuntimeConfig.authProviders.etherpad.path}/${roomId}`);
-
-            callbackDone && callbackDone();
-            setPadName('');
-            setIsLoading(false);
-        };
-
-        return (<Form onSubmit={(e) => { e.preventDefault(); createPasswordPad(); }}>
-            <input type="text" placeholder={t('Pad name')} value={padName} onChange={(e) => setPadName(e.target.value)} />
-            <input type="password" placeholder={t('Password')} value={password} onChange={(e) => setPassword(e.target.value)} />
-            <input type="password" placeholder={t('Confirm password')} value={validatePassword} onChange={(e) => setValidatePassword(e.target.value)} />
-            <button type="submit" disabled={!padName || !password || password !== validatePassword}>{ isLoading ? <LoadingSpinnerInline inverted /> :t('Create pad') }</button>
-        </Form>);
-    };
-
-    const ActionAuthoredPad = ({ callbackDone }) => {
-        const [padName, setPadName] = useState('');
-        const [isLoading, setIsLoading] = useState(false);
-
-        const createAuthoredPad = async () => {
-            setIsLoading(true);
-            const padId = await etherpad.createPad(padName, 'public');
-            if (!padId) {
-                setIsLoading(false);
-
-                return;
-            }
-            const link = getConfig().publicRuntimeConfig.authProviders.etherpad.baseUrl + '/' + padId;
-            const roomId = await createWriteRoom(link, padName);
-            router.push(`/${getConfig().publicRuntimeConfig.authProviders.etherpad.path}/${roomId}`);
-
-            callbackDone && callbackDone();
-            setPadName('');
-            setIsLoading(false);
-        };
-
-        return (
-            <Form onSubmit={(e) => { e.preventDefault(); createAuthoredPad(); }}>
-                <input type="text" placeholder={t('pad name')} value={padName} onChange={(e) => setPadName(e.target.value)} />
-                <button type="submit" disabled={!padName}>{ isLoading ? <LoadingSpinnerInline inverted /> : t('Create pad') }</button>
-            </Form>
-        );
-    };
-
     const submenuItems = _.filter([
-        { value: 'existingPad', actionComponentToRender: ActionExistingPad, label: t('Add existing pad') },
-        { value: 'anonymousPad', actionComponentToRender: ActionNewAnonymousPad, label: t('Create new anonymous pad') },
-        getConfig().publicRuntimeConfig.authProviders.etherpad.myPads?.api && { value: 'authoredPad', actionComponentToRender: ActionAuthoredPad, label: t('Create new authored pad') },
-        getConfig().publicRuntimeConfig.authProviders.etherpad.myPads?.api && { value: 'passwordPad', actionComponentToRender: ActionPasswordPad, label: t('Create password protected pad') },
+        { value: 'existingPad', actionComponentToRender: <AddExistingPad createWriteRoom={createWriteRoom} />, label: t('Add existing pad') },
+        { value: 'anonymousPad', actionComponentToRender: <CreateAnonymousPad createWriteRoom={createWriteRoom} />, label: t('Create new anonymous pad') },
+        getConfig().publicRuntimeConfig.authProviders.etherpad.myPads?.api && { value: 'authoredPad', actionComponentToRender: <CreateAuthoredPad createWriteRoom={createWriteRoom} />, label: t('Create new authored pad') },
+        getConfig().publicRuntimeConfig.authProviders.etherpad.myPads?.api && { value: 'passwordPad', actionComponentToRender: <CreatePasswordPad createWriteRoom={createWriteRoom} />, label: t('Create password protected pad') },
     ]);
 
     // Add the user's Matrix displayname as parameter so that it shows up in Etherpad as username

--- a/pages/etherpad/actions/AddExistingPad.js
+++ b/pages/etherpad/actions/AddExistingPad.js
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import getConfig from 'next/config';
+import { useRouter } from 'next/router';
+import { useTranslation } from 'react-i18next';
+
+import Form from '../../../components/UI/Form';
+import ErrorMessage from '../../../components/UI/ErrorMessage';
+import LoadingSpinnerInline from '../../../components/UI/LoadingSpinnerInline';
+
+export default function AddExistingPad({ callbackDone, createWriteRoom }) {
+    const router = useRouter();
+    const { t } = useTranslation('etherpad');
+
+    const [padName, setPadName] = useState('');
+    const [padLink, setPadLink] = useState('');
+    const [validLink, setValidLink] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const validatePadUrl = (e) => {
+        if (e.target.value.includes(getConfig().publicRuntimeConfig.authProviders.etherpad.baseUrl)) setValidLink(true);
+        else setValidLink(false);
+        setPadLink(e.target.value);
+    };
+
+    const handleExistingPadSubmit = async () => {
+        setIsLoading(true);
+        const roomId = await createWriteRoom(padLink, padName);
+
+        callbackDone && callbackDone();
+        setPadLink('');
+        setIsLoading(false);
+
+        router.push(`/${getConfig().publicRuntimeConfig.authProviders.etherpad.path}/${roomId}`);
+    };
+
+    return (
+        <Form onSubmit={(e) => { e.preventDefault(); handleExistingPadSubmit(); }}>
+            <input type="text" placeholder={t('Pad name')} value={padName} onChange={(e) => setPadName(e.target.value)} />
+            <input type="text" placeholder={t('Link to pad')} value={padLink} onChange={validatePadUrl} />
+            { !validLink && padLink && (
+                <ErrorMessage>
+                    { t('Make sure your link includes "{{url}}"', { url: getConfig().publicRuntimeConfig.authProviders.etherpad.baseUrl }) }
+                </ErrorMessage>
+            ) }
+            <button type="submit" disabled={!padName || !padLink || !validLink}>{ isLoading ? <LoadingSpinnerInline inverted /> : t('Add pad') }</button>
+        </Form>);
+}

--- a/pages/etherpad/actions/CreateAnonymousPad.js
+++ b/pages/etherpad/actions/CreateAnonymousPad.js
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useRouter } from 'next/router';
+import getConfig from 'next/config';
+
+import Form from '../../../components/UI/Form';
+import LoadingSpinnerInline from '../../../components/UI/LoadingSpinnerInline';
+
+export default function CreateAnonymousPad({ callbackDone, createWriteRoom }) {
+    const router = useRouter();
+    const { t } = useTranslation('etherpad');
+
+    const [padName, setPadName] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
+
+    const createAnonymousPad = async () => {
+        setIsLoading(true);
+        let string = '';
+        const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_';
+        const charactersLength = characters.length;
+        for (let i = 0; i < 20; i++) {
+            string += characters.charAt(Math.floor(Math.random() * charactersLength));
+        }
+        const link = getConfig().publicRuntimeConfig.authProviders.etherpad.baseUrl + '/' + string;
+        const roomId = await createWriteRoom(link, padName);
+
+        callbackDone && callbackDone();
+        setIsLoading(false);
+        setPadName('');
+
+        // Forward the user and show the newly created pad
+        router.push(`/${getConfig().publicRuntimeConfig.authProviders.etherpad.path}/${roomId}`);
+    };
+
+    return (
+        <Form onSubmit={(e) => { e.preventDefault(); createAnonymousPad(padName); }}>
+            <input type="text" placeholder={t('Pad name')} value={padName} onChange={(e) => setPadName(e.target.value)} />
+            <button type="submit" disabled={!padName}>{ isLoading ? <LoadingSpinnerInline inverted /> : t('Create pad') }</button>
+        </Form>
+    );
+}

--- a/pages/etherpad/actions/CreateAuthoredPad.js
+++ b/pages/etherpad/actions/CreateAuthoredPad.js
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import getConfig from 'next/config';
+import { useRouter } from 'next/router';
+import { useTranslation } from 'react-i18next';
+
+import Form from '../../../components/UI/Form';
+import LoadingSpinnerInline from '../../../components/UI/LoadingSpinnerInline';
+import { useAuth } from '../../../lib/Auth';
+
+export default function CreateAuthoredPad({ callbackDone, createWriteRoom }) {
+    const router = useRouter();
+    const { t } = useTranslation('etherpad');
+
+    const auth = useAuth();
+    const etherpad = auth.getAuthenticationProvider('etherpad');
+
+    const [padName, setPadName] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
+
+    const createAuthoredPad = async () => {
+        setIsLoading(true);
+        const padId = await etherpad.createPad(padName, 'public');
+        if (!padId) {
+            setIsLoading(false);
+
+            return;
+        }
+        const link = getConfig().publicRuntimeConfig.authProviders.etherpad.baseUrl + '/' + padId;
+        const roomId = await createWriteRoom(link, padName);
+        router.push(`/${getConfig().publicRuntimeConfig.authProviders.etherpad.path}/${roomId}`);
+
+        callbackDone && callbackDone();
+        setPadName('');
+        setIsLoading(false);
+    };
+
+    return (
+        <Form onSubmit={(e) => { e.preventDefault(); createAuthoredPad(); }}>
+            <input type="text" placeholder={t('pad name')} value={padName} onChange={(e) => setPadName(e.target.value)} />
+            <button type="submit" disabled={!padName}>{ isLoading ? <LoadingSpinnerInline inverted /> : t('Create pad') }</button>
+        </Form>
+    );
+}

--- a/pages/etherpad/actions/CreatePasswordPad.js
+++ b/pages/etherpad/actions/CreatePasswordPad.js
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import getConfig from 'next/config';
+import { useTranslation } from 'react-i18next';
+
+import Form from '../../../components/UI/Form';
+import LoadingSpinnerInline from '../../../components/UI/LoadingSpinnerInline';
+import { useAuth } from '../../../lib/Auth';
+
+export default function CreatePasswordPad({ callbackDone, createWriteRoom }) {
+    const router = useRouter();
+    const { t } = useTranslation('etherpad');
+
+    const auth = useAuth();
+    const etherpad = auth.getAuthenticationProvider('etherpad');
+
+    const [padName, setPadName] = useState('');
+    const [password, setPassword] = useState('');
+    const [validatePassword, setValidatePassword] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
+
+    const createPasswordPad = async () => {
+        setIsLoading(true);
+        const padId = await etherpad.createPad(padName, 'private', password);
+        const link = getConfig().publicRuntimeConfig.authProviders.etherpad.baseUrl + '/' + padId;
+        const roomId = await createWriteRoom(link, padName);
+        router.push(`/${getConfig().publicRuntimeConfig.authProviders.etherpad.path}/${roomId}`);
+
+        callbackDone && callbackDone();
+        setPadName('');
+        setIsLoading(false);
+    };
+
+    return (<Form onSubmit={(e) => { e.preventDefault(); createPasswordPad(); }}>
+        <input type="text" placeholder={t('Pad name')} value={padName} onChange={(e) => setPadName(e.target.value)} />
+        <input type="password" placeholder={t('Password')} value={password} onChange={(e) => setPassword(e.target.value)} />
+        <input type="password" placeholder={t('Confirm password')} value={validatePassword} onChange={(e) => setValidatePassword(e.target.value)} />
+        <button type="submit" disabled={!padName || !password || password !== validatePassword}>{ isLoading ? <LoadingSpinnerInline inverted /> :t('Create pad') }</button>
+    </Form>);
+}


### PR DESCRIPTION
I think this is going to help keeping an overview with the repository, and reduces that enormous `[[...roomId]].js` file to have fewer lines... breaks it up a little.

Aside from splitting up these components into their own files this also helps rendering performance: We should defer from creating sub-components inside components. So we should avoid this:

```js
const MotherComponent = () => {
    ...

    const ChildOne = () => {
        return <div>Child1</div>;
    }
    const ChildTwo = () => {
        return <div>Child2</div>;
    }

    return (
        <ChildOne />
        <ChildTwo />
    );
}
```

Every time that `MotherComponent` gets re-rendered, it will also create those child components from scratch.
Even though they don't actually change. Like in this case with the `/etherpad` page: the service submenu action forms (e.g. to create a new anonymous pad, or to create a new password pad, and so on...) will always remain the same. Disregarding which pad we're currently looking at. So there's no point in having to redefine and re-create them every time that the `/etherpad` page re-renders.

By moving each action into its own file this stops from happening. It will be defined once. And React does its magic to re-use them whenever possible, and only re-renders them if really needed.

Let's stick to this for newly created code. 🚀 