### PR TITLE
Etherpad: Remove unnecessary state

### DIFF
--- a/pages/etherpad/[[...roomId]].js
+++ b/pages/etherpad/[[...roomId]].js
@@ -29,7 +29,6 @@ export default function Etherpad() {
     const router = useRouter();
     const [serverPads, setServerPads] = useState({});
     const [isDeletingPad, setIsDeletingPad] = useState(false);
-    const [content, setContent] = useState(matrix.roomContents.get(roomId));
 
     /**
      * A roomId is set when the route is /write/<roomId>, otherwise it's undefined
@@ -52,7 +51,7 @@ export default function Etherpad() {
      *
      * @type {{name: string, group: string, users: [], visibility: string, readonly, _id: string, ctime: number}|undefined}
      */
-    const mypadsPadObject = roomId && content && content.body && serverPads[content.body.substring(content.body.lastIndexOf('/') + 1)];
+    const mypadsPadObject = roomId && matrix.roomContents.get(roomId)?.body && serverPads[matrix.roomContents.get(roomId).body.substring(matrix.roomContents.get(roomId).body.lastIndexOf('/') + 1)];
 
     // Whenever the roomId changes (e.g. after a new pad was created), automatically focus that element.
     // This makes the sidebar scroll to the element if it is outside of the current viewport.
@@ -60,16 +59,6 @@ export default function Etherpad() {
     useEffect(() => {
         selectedPadRef.current?.focus();
     }, [roomId]);
-
-    useEffect(() => {
-        let cancelled = false;
-
-        // @TODO: Similar to above, this seems unnecessary. Here we store the contents of a given Matrix room,
-        // which already lives in a `useState` in Matrix.js, in yet another `useState` here in this component?!?
-        !cancelled && setContent(matrix.roomContents.get(roomId));
-
-        return () => { cancelled = true; };
-    }, [matrix.roomContents, roomId]);
 
     useEffect(() => {
         let cancelled = false;
@@ -100,7 +89,7 @@ export default function Etherpad() {
             if (matrix?.spaces.get(matrix.serviceSpaces.etherpad).children) {
                 // if there are rooms within the space id we grab the names of those room
                 for (const roomId of matrix.spaces.get(matrix.serviceSpaces.etherpad).children) {
-                    if (!matrix.rooms.get(roomId) || !matrix.roomContents.get(roomId)) { continue; }
+                    if (!matrix.rooms.get(roomId) || !matrix.roomContents.get(roomId)?.body) { continue; }
                     // in order to get the actual id of the pad we need to check the room content
                     const id = matrix.roomContents.get(roomId).body.substring(matrix.roomContents.get(roomId).body.lastIndexOf('/') + 1);
                     matrixPads = Object.assign({}, matrixPads, {
@@ -126,7 +115,7 @@ export default function Etherpad() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [matrix.serviceSpaces.etherpad, serverPads, createWriteRoom]);
 
-    const copyToClipboard = () => navigator.clipboard.writeText(content.body);
+    const copyToClipboard = () => navigator.clipboard.writeText(matrix.roomContents.get(roomId).body);
 
     /**
      * Removes the given pad from the user's library, and also deletes the pad entirely via API if possible.
@@ -309,8 +298,8 @@ export default function Etherpad() {
 
     // Add the user's Matrix displayname as parameter so that it shows up in Etherpad as username
     let iframeUrl;
-    if (roomId && content && content.body) {
-        iframeUrl = new URL(content.body);
+    if (roomId && matrix.roomContents.get(roomId)?.body) {
+        iframeUrl = new URL(matrix.roomContents.get(roomId).body);
         iframeUrl.searchParams.set('userName', auth.user.displayname);
     }
 
@@ -344,7 +333,7 @@ export default function Etherpad() {
                     </>
                 ) }
             </IframeLayout.Sidebar>
-            { roomId && content && (
+            { roomId && matrix.roomContents.get(roomId) && (
                 <IframeLayout.IframeWrapper>
                     <IframeLayout.IframeHeader>
                         <h2>{ matrix.rooms.get(roomId).name }</h2>


### PR DESCRIPTION
This removes the `content` state variable in the Etherpad component. Essentially we're storing it twice, as mentioned in the comment in the code. We don't need to store it here again, if `matrix.roomContents` does hold the exact same information already.