### PR TITLE
Add 'connection lost' banner to the UI and display it whenever there is no connection to the server.

### DIFF
--- a/components/DisplayLostConnection.js
+++ b/components/DisplayLostConnection.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useTranslation } from 'react-i18next';
+
+import { useAuth } from '../lib/Auth';
+import { useMatrix } from '../lib/Matrix';
+import LoadingSpinnerInline from './UI/LoadingSpinnerInline';
+
+const NoConnectionView = styled.div`
+  position: absolute;
+  right: var(--margin);
+  bottom: var(--margin);
+  display: grid;
+  grid-auto-flow: column;
+  grid-gap: calc(var(--margin)/2);
+  place-items: center;
+  padding: calc(var(--margin)/2) var(--margin);
+  color: white;
+  text-transform: uppercase;
+  background-color: #ff2f4f;
+  border-radius: 4px;
+
+`;
+const DisplayLostConnection = (params) => {
+    const auth = useAuth();
+    const matrix = useMatrix(auth.getAuthenticationProvider('matrix'));
+    const { t } = useTranslation();
+
+    if (matrix.isConnectedToServer) return null;
+
+    return (
+        <NoConnectionView>
+            <small>
+                { t('Waiting for server') }
+            </small>
+            <LoadingSpinnerInline inverted />
+        </NoConnectionView>
+    );
+};
+
+export default DisplayLostConnection;

--- a/lib/Matrix.js
+++ b/lib/Matrix.js
@@ -16,7 +16,7 @@ function useMatrixProvider(activeMatrixAuthenticationProviders) {
         const [initialSyncDone, setInitialSyncDone] = useState(false);
         const [applicationsFolder, setApplicationsFolder] = useState('');
         const [serviceSpaces, setServiceSpaces] = useState({});
-        const [connectionStatus, setConnectionStatus] = useState(false);
+        const [isConnectedToServer, setIsConnectedToServer] = useState(true);
 
         const buildRoomObject = useCallback((roomId) => {
             const room = matrixClient.getRoom(roomId);
@@ -172,16 +172,17 @@ function useMatrixProvider(activeMatrixAuthenticationProviders) {
         });
 
         const SyncEvent = useCallback((newState, prevState) => {
+            if (newState === 'SYNCING') setIsConnectedToServer(true);
             if (newState === 'SYNCING' && prevState === 'PREPARED') {
-                setConnectionStatus(true);
                 (async () => {
                     const mDirectEventContent = await matrixClient.getAccountDataFromServer('m.direct');
                     hydrateDirectMessages(mDirectEventContent);
                     setInitialSyncDone(true);
                 })();
             }
-            if (newState === 'ERROR' || newState === 'RECONNECTING' || newState === 'STOPPED') {
-                setConnectionStatus(false);
+            if (newState === 'ERROR' || newState === 'STOPPED') {
+                // if we"ve lost connection to the server we set our state to false
+                setIsConnectedToServer(false);
             }
         });
 
@@ -319,7 +320,7 @@ function useMatrixProvider(activeMatrixAuthenticationProviders) {
             leaveRoom,
             createRoom,
             hydrateRoomContent,
-            connectionStatus,
+            isConnectedToServer,
         };
     })(authenticationProvider));
 }

--- a/lib/Matrix.js
+++ b/lib/Matrix.js
@@ -16,6 +16,7 @@ function useMatrixProvider(activeMatrixAuthenticationProviders) {
         const [initialSyncDone, setInitialSyncDone] = useState(false);
         const [applicationsFolder, setApplicationsFolder] = useState('');
         const [serviceSpaces, setServiceSpaces] = useState({});
+        const [connectionStatus, setConnectionStatus] = useState(false);
 
         const buildRoomObject = useCallback((roomId) => {
             const room = matrixClient.getRoom(roomId);
@@ -77,14 +78,14 @@ function useMatrixProvider(activeMatrixAuthenticationProviders) {
 
         const setMessages = (roomId) => {
             const buildRoomContentObject = (roomId) => {
-            // we check rooms for timeline events of the type 'm.room.message' and populate it with the last event, therefore the newest message
+                // we check rooms for timeline events of the type 'm.room.message' and populate it with the last event, therefore the newest message
                 const room = matrixClient.getRoom(roomId);
                 if (!room) return;
                 const messages = room.timeline.filter(timeline => timeline.event.type === 'm.room.message');
                 if (messages.length === 0) return;
 
                 // we return the last array index. this coould also be replaced with the entire array if we need version control or undo functions in the future
-                return messages[messages.length-1].event.content;
+                return messages[messages.length - 1].event.content;
             };
 
             return (prevState) => {
@@ -172,11 +173,15 @@ function useMatrixProvider(activeMatrixAuthenticationProviders) {
 
         const SyncEvent = useCallback((newState, prevState) => {
             if (newState === 'SYNCING' && prevState === 'PREPARED') {
+                setConnectionStatus(true);
                 (async () => {
                     const mDirectEventContent = await matrixClient.getAccountDataFromServer('m.direct');
                     hydrateDirectMessages(mDirectEventContent);
                     setInitialSyncDone(true);
                 })();
+            }
+            if (newState === 'ERROR' || newState === 'RECONNECTING' || newState === 'STOPPED') {
+                setConnectionStatus(false);
             }
         });
 
@@ -314,6 +319,7 @@ function useMatrixProvider(activeMatrixAuthenticationProviders) {
             leaveRoom,
             createRoom,
             hydrateRoomContent,
+            connectionStatus,
         };
     })(authenticationProvider));
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -10,6 +10,7 @@ import { MatrixContext, useMatrixProvider } from '../lib/Matrix';
 import '/assets/_globalCss.css';
 import { DefaultLayout } from '../components/layouts/default';
 import MatrixAuthProvider from '../lib/auth/MatrixAuthProvider';
+import DisplayLostConnection from '../components/DisplayLostConnection';
 
 const guestRoutes = ['/', '/login'];
 
@@ -43,6 +44,7 @@ export default function App({ Component, pageProps }) {
             </Head>
             <AuthContext.Provider value={authData}>
                 <MatrixContext.Provider value={matrixData}>
+                    <DisplayLostConnection />
                     <Layout>
                         { (authData.user || guestRoutes.includes(router.route)) && (
                             <Component {...pageProps} />


### PR DESCRIPTION
Displays a red banner whenever the connection to the matrix server is lost.

- [x] add state within `Matrix.js` to save the current connection state
- [x] display a UI element whenever the connection state is `false`


