### PR TITLE
Add 'connection lost' banner to the UI and display it whenever there is no connection to the server.

### DIFF
--- a/components/UI/DisplayLostConncetion.js
+++ b/components/UI/DisplayLostConncetion.js
@@ -2,9 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 
-import { useAuth } from '../lib/Auth';
-import { useMatrix } from '../lib/Matrix';
-import LoadingSpinnerInline from './UI/LoadingSpinnerInline';
+import { useAuth } from '../../lib/Auth';
+import { useMatrix } from '../../lib/Matrix';
+import LoadingSpinnerInline from './LoadingSpinnerInline';
 
 const NoConnectionView = styled.div`
   position: absolute;
@@ -21,9 +21,9 @@ const NoConnectionView = styled.div`
   border-radius: 4px;
 
 `;
-const DisplayLostConnection = (params) => {
+const DisplayLostConnection = () => {
     const auth = useAuth();
-    const matrix = useMatrix(auth.getAuthenticationProvider('matrix'));
+    const matrix =useMatrix(auth.getAuthenticationProvider('matrix'));
     const { t } = useTranslation();
 
     if (matrix.isConnectedToServer) return null;

--- a/components/UI/DisplayLostConncetion.js
+++ b/components/UI/DisplayLostConncetion.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useTranslation } from 'react-i18next';
+
+import { useAuth } from '../lib/Auth';
+import { useMatrix } from '../lib/Matrix';
+import LoadingSpinnerInline from './UI/LoadingSpinnerInline';
+
+const NoConnectionView = styled.div`
+  position: absolute;
+  right: var(--margin);
+  bottom: var(--margin);
+  display: grid;
+  grid-auto-flow: column;
+  grid-gap: calc(var(--margin)/2);
+  place-items: center;
+  padding: calc(var(--margin)/2) var(--margin);
+  color: white;
+  text-transform: uppercase;
+  background-color: #ff2f4f;
+  border-radius: 4px;
+
+`;
+const DisplayLostConnection = (params) => {
+    const auth = useAuth();
+    const matrix = useMatrix(auth.getAuthenticationProvider('matrix'));
+    const { t } = useTranslation();
+
+    if (matrix.isConnectedToServer) return null;
+
+    return (
+        <NoConnectionView>
+            <small>
+                { t('Waiting for server') }
+            </small>
+            <LoadingSpinnerInline inverted />
+        </NoConnectionView>
+    );
+};
+
+export default DisplayLostConnection;

--- a/components/UI/LostConnection.js
+++ b/components/UI/LostConnection.js
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import LoadingSpinnerInline from './LoadingSpinnerInline';
 
-const NoConnectionView = styled.div`
+const LostConnectionView = styled.div`
   position: absolute;
   right: var(--margin);
   bottom: var(--margin);
@@ -17,18 +17,18 @@ const NoConnectionView = styled.div`
   text-transform: uppercase;
   background-color: #ff2f4f;
   border-radius: 4px;
-
 `;
+
 const LostConnection = () => {
     const { t } = useTranslation();
 
     return (
-        <NoConnectionView>
+        <LostConnectionView>
             <small>
                 { t('Connection lost') }
             </small>
             <LoadingSpinnerInline inverted />
-        </NoConnectionView>
+        </LostConnectionView>
     );
 };
 

--- a/components/UI/LostConnection.js
+++ b/components/UI/LostConnection.js
@@ -25,7 +25,7 @@ const LostConnection = () => {
     return (
         <NoConnectionView>
             <small>
-                { t('Waiting for server') }
+                { t('Connection lost') }
             </small>
             <LoadingSpinnerInline inverted />
         </NoConnectionView>

--- a/components/UI/LostConnection.js
+++ b/components/UI/LostConnection.js
@@ -21,7 +21,7 @@ const NoConnectionView = styled.div`
   border-radius: 4px;
 
 `;
-const DisplayLostConnection = () => {
+const LostConnection = () => {
     const auth = useAuth();
     const matrix =useMatrix(auth.getAuthenticationProvider('matrix'));
     const { t } = useTranslation();
@@ -38,4 +38,4 @@ const DisplayLostConnection = () => {
     );
 };
 
-export default DisplayLostConnection;
+export default LostConnection;

--- a/components/UI/LostConnection.js
+++ b/components/UI/LostConnection.js
@@ -2,8 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 
-import { useAuth } from '../../lib/Auth';
-import { useMatrix } from '../../lib/Matrix';
 import LoadingSpinnerInline from './LoadingSpinnerInline';
 
 const NoConnectionView = styled.div`
@@ -22,11 +20,7 @@ const NoConnectionView = styled.div`
 
 `;
 const LostConnection = () => {
-    const auth = useAuth();
-    const matrix =useMatrix(auth.getAuthenticationProvider('matrix'));
     const { t } = useTranslation();
-
-    if (matrix.isConnectedToServer) return null;
 
     return (
         <NoConnectionView>

--- a/lib/Matrix.js
+++ b/lib/Matrix.js
@@ -181,7 +181,7 @@ function useMatrixProvider(auth) {
                 setInitialSyncDone(true);
             })();
         }
-        if (newState === 'ERROR' || newState === 'STOPPED') {
+        if (newState === 'ERROR') {
             // if we've lost connection to the server we set our state to false
             setIsConnectedToServer(false);
         }

--- a/lib/Matrix.js
+++ b/lib/Matrix.js
@@ -17,6 +17,7 @@ function useMatrixProvider(auth) {
     const [initialSyncDone, setInitialSyncDone] = useState(false);
     const [applicationsFolder, setApplicationsFolder] = useState('');
     const [serviceSpaces, setServiceSpaces] = useState({});
+    const [isConnectedToServer, setIsConnectedToServer] = useState(true);
 
     const buildRoomObject = useCallback((roomId) => {
         const room = matrixClient.getRoom(roomId);
@@ -172,12 +173,17 @@ function useMatrixProvider(auth) {
     });
 
     const SyncEvent = useCallback((newState, prevState) => {
+        if (newState === 'SYNCING') setIsConnectedToServer(true); // if there is a connection to the server we set our state to true
         if (newState === 'SYNCING' && prevState === 'PREPARED') {
             (async () => {
                 const mDirectEventContent = await matrixClient.getAccountDataFromServer('m.direct');
                 hydrateDirectMessages(mDirectEventContent);
                 setInitialSyncDone(true);
             })();
+        }
+        if (newState === 'ERROR' || newState === 'STOPPED') {
+            // if we"ve lost connection to the server we set our state to false
+            setIsConnectedToServer(false);
         }
     });
 
@@ -314,6 +320,7 @@ function useMatrixProvider(auth) {
         leaveRoom,
         createRoom,
         hydrateRoomContent,
+        isConnectedToServer,
     };
 }
 

--- a/lib/Matrix.js
+++ b/lib/Matrix.js
@@ -182,7 +182,7 @@ function useMatrixProvider(auth) {
             })();
         }
         if (newState === 'ERROR' || newState === 'STOPPED') {
-            // if we"ve lost connection to the server we set our state to false
+            // if we've lost connection to the server we set our state to false
             setIsConnectedToServer(false);
         }
     });

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -7,8 +7,8 @@ import { DefaultLayout } from '../components/layouts/default';
 import { AuthContext, useAuthProvider } from '../lib/Auth';
 import { MatrixContext, useMatrixProvider } from '../lib/Matrix';
 import '../lib/Internationalization';
-
 import '/assets/_globalCss.css';
+import DisplayLostConnection from '../components/UI/DisplayLostConncetion';
 
 const guestRoutes = ['/', '/login'];
 
@@ -43,6 +43,7 @@ export default function App({ Component, pageProps }) {
             </Head>
             <AuthContext.Provider value={authData}>
                 <MatrixContext.Provider value={matrixData}>
+                    <DisplayLostConnection />
                     <Layout>
                         { (authData.user || guestRoutes.includes(router.route)) && (
                             <Component {...pageProps} />

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -8,7 +8,7 @@ import { AuthContext, useAuthProvider } from '../lib/Auth';
 import { MatrixContext, useMatrixProvider } from '../lib/Matrix';
 import '../lib/Internationalization';
 import '/assets/_globalCss.css';
-import DisplayLostConnection from '../components/UI/DisplayLostConncetion';
+import LostConnection from '../components/UI/LostConnection';
 
 const guestRoutes = ['/', '/login'];
 
@@ -43,7 +43,7 @@ export default function App({ Component, pageProps }) {
             </Head>
             <AuthContext.Provider value={authData}>
                 <MatrixContext.Provider value={matrixData}>
-                    <DisplayLostConnection />
+                    { !matrixData.isConnectedToServer && <LostConnection /> }
                     <Layout>
                         { (authData.user || guestRoutes.includes(router.route)) && (
                             <Component {...pageProps} />

--- a/public/locales/de/_defaults.json
+++ b/public/locales/de/_defaults.json
@@ -2,5 +2,6 @@
     "Password": "Passwort",
     "Select action": "Aktion wählen",
     "What would you like to do?": "Was möchtest Du tun?",
-    "{{error}}, please wait {{time}} seconds.": "{{error}}, bitte warte {{time}} sekunden."
+    "{{error}}, please wait {{time}} seconds.": "{{error}}, bitte warte {{time}} sekunden.",
+    "Connection Lost": "Verbindung unterbrochen"
 }

--- a/public/locales/de/_defaults.json
+++ b/public/locales/de/_defaults.json
@@ -2,6 +2,6 @@
     "Password": "Passwort",
     "Select action": "Aktion wählen",
     "What would you like to do?": "Was möchtest Du tun?",
-    "{{error}}, please wait {{time}} seconds.": "{{error}}, bitte warte {{time}} sekunden.",
-    "Connection Lost": "Verbindung unterbrochen"
+    "{{error}}, please wait {{time}} seconds.": "{{error}}, bitte warte {{time}} Sekunden.",
+    "Connection lost": "Verbindung unterbrochen"
 }


### PR DESCRIPTION
Displays a red banner whenever the connection to the matrix server is lost.

- [x] add state within `Matrix.js` to save the current connection state
- [x] display a UI element whenever the connection state is `false`


