### PR TITLE
Ensure service spaces are within applications folder

### DIFF
--- a/lib/Matrix.js
+++ b/lib/Matrix.js
@@ -231,13 +231,11 @@ function useMatrixProvider(auth) {
 
     useEffect(() => {
         const lookForServiceSpaces = async () => {
-            // @TODO We do not actually ensure that the service spaces we search for are a child space of the
-            // "Applications" space we found previously. I assume we want to ensure that though.
             const serviceSpaces = {};
             for (const element of Object.keys(getConfig().publicRuntimeConfig.authProviders)) {
                 if (element === 'matrix') continue; // we don't want to create a service folder for matrix
-
-                const existingServiceSpace = Array.from(spaces.values()).find(space => space.name === element);
+                const applicationsChildren = spaces.get(applicationsFolder).children.map(child => spaces.get(child));
+                const existingServiceSpace = applicationsChildren.find(space => space.name === element);
                 if (existingServiceSpace) {
                     logger.debug('Found existing service space', { serviceType: element, existingServiceSpace });
                     serviceSpaces[element] = existingServiceSpace.roomId;


### PR DESCRIPTION
Only loop through all children of the applications folder when looking for service spaces, instead of looking through all available spaces.