### PR TITLE
fix: vertically align service buttons on `/etherpad` and `/spacedeck`

### DIFF
--- a/components/layouts/iframe.js
+++ b/components/layouts/iframe.js
@@ -76,15 +76,6 @@ const IframeHeaderButtonWrapper = styled.div`
   grid-auto-flow: column;
   grid-gap: calc(var(--margin));
   height: 100%;
-
-  button {
-    /* unset globally defined button styles; set height to line-height */
-    width: unset;
-    height: calc(var(--margin) * 1.3);
-    padding: unset;
-    background-color: unset;
-    border: unset;
-  }
 `;
 
 const Layout = ({ children }) => {

--- a/pages/etherpad/[[...roomId]].js
+++ b/pages/etherpad/[[...roomId]].js
@@ -9,6 +9,7 @@ import { useMatrix } from '../../lib/Matrix';
 import ErrorMessage from '../../components/UI/ErrorMessage';
 import IframeLayout from '../../components/layouts/iframe';
 import { ServiceSubmenu } from '../../components/UI/ServiceSubmenu';
+import TextButton from '../../components/UI/TextButton';
 import BinIcon from '../../assets/icons/bin.svg';
 import { ServiceTable } from '../../components/UI/ServiceTable';
 import LoadingSpinnerInline from '../../components/UI/LoadingSpinnerInline';
@@ -227,9 +228,9 @@ export default function Etherpad() {
                         <h2>{ matrix.rooms.get(roomId).name }</h2>
                         <IframeLayout.IframeHeaderButtonWrapper>
                             <CopyToClipboard title={t('Copy pad link to clipboard')} content={matrix.roomContents.get(roomId)?.body} />
-                            <button title={t(mypadsPadObject ? 'Delete pad' : 'Remove pad from my library')} onClick={deletePad}>
+                            <TextButton title={t(mypadsPadObject ? 'Delete pad' : 'Remove pad from my library')} onClick={deletePad}>
                                 { isDeletingPad ? <LoadingSpinnerInline /> : <BinIcon fill="var(--color-foreground)" /> }
-                            </button>
+                            </TextButton>
                         </IframeLayout.IframeHeaderButtonWrapper>
                     </IframeLayout.IframeHeader>
                     <iframe src={iframeUrl.toString()} />

--- a/pages/spacedeck/[[...roomId]].js
+++ b/pages/spacedeck/[[...roomId]].js
@@ -11,6 +11,7 @@ import LoadingSpinnerInline from '../../components/UI/LoadingSpinnerInline';
 import { useAuth } from '../../lib/Auth';
 import { useMatrix } from '../../lib/Matrix';
 import ErrorMessage from '../../components/UI/ErrorMessage';
+import TextButton from '../../components/UI/TextButton';
 import Bin from '../../assets/icons/bin.svg';
 import { ServiceSubmenu } from '../../components/UI/ServiceSubmenu';
 import IframeLayout from '../../components/layouts/iframe';
@@ -218,9 +219,9 @@ export default function Spacedeck() {
                         <h2>{ matrix.rooms.get(roomId).name }</h2>
                         <IframeLayout.IframeHeaderButtonWrapper>
                             <CopyToClipboard title={t('Copy sketch link to clipboard')} content={content.body} />
-                            <button title={t('Delete sketch')} onClick={removeSketch}>
+                            <TextButton title={t('Delete sketch')} onClick={removeSketch}>
                                 { isDeletingSketch ? <LoadingSpinnerInline /> : <Bin fill="var(--color-foreground)" /> }
-                            </button>
+                            </TextButton>
                         </IframeLayout.IframeHeaderButtonWrapper>
                     </IframeLayout.IframeHeader>
                     <iframe src={content.body} />


### PR DESCRIPTION
![demo](https://github.com/medienhaus/medienhaus-spaces/assets/63073125/8f3cc567-b4a2-4ffb-8f0c-9fc4470353d7)
