### PR TITLE
Catch errors when validating login tokens 

### DIFF
--- a/lib/Auth.js
+++ b/lib/Auth.js
@@ -6,6 +6,7 @@ import MatrixAuthProvider from './auth/MatrixAuthProvider';
 import PeerTubeAuthProvider from './auth/PeerTubeAuthProvider';
 import MyPadsAuthProvider from './auth/MyPadsAuthProvider';
 import SpacedeckAuthProvider from './auth/SpacedeckAuthProvider';
+import logger from './Logging';
 
 /*
     Mapping of authentication provider types and which corresponding class should be used to actually perform
@@ -74,10 +75,9 @@ function useAuthProvider() {
     };
 
     const getAccessTokensFromAccountData = async (username, password) => {
-        // we will use `getAccountDataFromServer` instead of `getAccountData` as we can not tell for sure if the sync is completely done and dont want to wait for that. So potentially this call is avoidable but it is more manageable to handle it like this.
+        // we will use `getAccountDataFromServer` instead of `getAccountData` as we can not tell for sure if the sync is completely done and don't want to wait for that. So potentially this call is avoidable, but it is more manageable to handle it like this.
+        // if there is no account data set we initialise an empty object
         const accessTokens = await getAuthenticationProvider('matrix').getMatrixClient().getAccountDataFromServer('dev.medienhaus.spaces.accesstokens') || {};
-        // fetch did not worked or this accountData state event is not set yet. In either way we want to create it.
-        let dataChanged = false;
 
         for await (const [type, authentication] of Object.entries(activeAuthentications)) {
             // Skip the default Matrix auth provider
@@ -85,20 +85,16 @@ function useAuthProvider() {
 
             if (accessTokens[type]) {
                 authentication.addToken(accessTokens[type]);
-                const tokenValidation = await authentication.validateToken();
-                if (tokenValidation) {
-                    // everything seems to work out as expected we will cut here
-                    continue;
-                }
+                await authentication.validateToken()
+                    .catch(async () => {
+                        accessTokens[type] = await authentication.signin(username, password)
+                            .catch(() => {
+                                //@TODO actual error handling when login fails
+                                logger.debug('{{service}} login failed', { service: type });
+                            });
+                        await getAuthenticationProvider('matrix').getMatrixClient().setAccountData('dev.medienhaus.spaces.accesstokens', accessTokens);
+                    });
             }
-            // if the stored token does not work anymore then we will execute a login procedure and store the new generated accesstoken
-            dataChanged = true;
-            accessTokens[type] = await authentication.signin(username, password).catch(() => { });
-        }
-
-        if (dataChanged) {
-            // write accessTokensToAccountData. this contition is needed to prevent spamming with calls towards the [matrix] server, even if the accesstokens are all still valid and doesnt need to be updated.
-            await getAuthenticationProvider('matrix').getMatrixClient().setAccountData('dev.medienhaus.spaces.accesstokens', accessTokens);
         }
     };
 


### PR DESCRIPTION
Catch errors when validating login tokens and use catch block to try si… gning in again. remove unnecessary variable and update account data after successfully signing in