### PR TITLE
fix: Stop creating multiple "Applications" spaces (and service sub-spaces)

### DIFF
--- a/lib/Matrix.js
+++ b/lib/Matrix.js
@@ -216,7 +216,11 @@ function useMatrixProvider(auth) {
     }, [authenticationProvider, rooms, setRoom, spaces]);
 
     useEffect(() => {
-        const lookForApplicationsFolder = async () => {
+        let cancelled = false;
+
+        const lookForApplicationsFolder = _.debounce(async () => {
+            if (cancelled) return;
+
             const spacesToScan = Array.from(spaces.values());
             const existingApplicationsSpace = spacesToScan.find(space => space.meta?.template === 'applications');
             logger.debug('Trying to find "Applications" space...', { spacesToScan });
@@ -236,26 +240,39 @@ function useMatrixProvider(auth) {
                 logger.debug('Created new "Applications" space', { newApplicationsSpace });
                 setApplicationsFolder(newApplicationsSpace);
             }
-        };
+        }, 1000);
 
         initialSyncDone && lookForApplicationsFolder();
+
+        return () => {
+            cancelled = true;
+        };
     }, [createRoom, initialSyncDone, spaces]);
 
     useEffect(() => {
-        const lookForServiceSpaces = async () => {
+        let cancelled = false;
+
+        const lookForServiceSpaces = _.debounce(async () => {
+            if (cancelled) return;
+            if (!spaces.get(applicationsFolder)) return;
+
             const serviceSpaces = {};
+            const applicationsChildren = spaces
+                .get(applicationsFolder)
+                ?.children  // Retrieve the 'children' property of the 'applicationsFolder' object
+                .map(child => spaces.get(child)) // Map over the 'children' array and fetch the corresponding objects from the 'spaces' map
+                .filter(child => child !== undefined); // Filter out any undefined values to ensure 'applicationsChildren' only contains valid objects
+
             for (const element of Object.keys(getConfig().publicRuntimeConfig.authProviders)) {
                 if (element === 'matrix') continue; // we don't want to create a service folder for matrix
-                const applicationsChildren = spaces
-                    .get(applicationsFolder)
-                    .children  // Retrieve the 'children' property of the 'applicationsFolder' object
-                    .map(child => spaces.get(child)) // Map over the 'children' array and fetch the corresponding objects from the 'spaces' map
-                    .filter(child => child !== undefined); // Filter out any undefined values to ensure 'applicationsChildren' only contains valid objects
+
                 const existingServiceSpace = applicationsChildren.find(space => space.name === element);
                 if (existingServiceSpace) {
                     logger.debug('Found existing service space', { serviceType: element, existingServiceSpace });
                     serviceSpaces[element] = existingServiceSpace.roomId;
                 } else {
+                    if (cancelled) return;
+
                     logger.debug('Creating new service space...', { serviceType: element });
                     const roomId = await createRoom(
                         element,
@@ -270,8 +287,13 @@ function useMatrixProvider(auth) {
                 }
             }
             setServiceSpaces(serviceSpaces);
-        };
+        }, 1000);
+
         applicationsFolder && lookForServiceSpaces();
+
+        return () => {
+            cancelled = true;
+        };
     }, [applicationsFolder, authenticationProvider, createRoom, spaces]);
 
     const leaveRoom = async (roomId) => {


### PR DESCRIPTION
When we fixed the dependency arrays for `useEffect` and `useCallback` 2 weeks ago (see https://github.com/medienhaus/medienhaus-spaces/commit/1456c86b4186cabdfeccfec91f8069878381a22c) we also re-introduced (and possibly worsened) a race condition that would result in the app creating tons of Matrix spaces:
<img width="775" alt="image" src="https://github.com/medienhaus/medienhaus-spaces/assets/706419/81a50f81-e119-43f7-b997-c90b96917ebb">

---

This change fixes creating multiple "Applications" spaces (and service sub-spaces) by `_.debounce`-ing the processes.

🚨 Hacky-hack alert: This is to counter the race conditions happening because of the `Matrix.js` React hook being mounted/unmounted way too often at the moment. The more correct solution would be to reduce the staggering amount of renderings happening; until then this should be seen as a band-aid.