### PR TITLE
style: introduce `--line-height` and `--icon-size` css variables

### DIFF
--- a/assets/_globalCss.css
+++ b/assets/_globalCss.css
@@ -8,6 +8,8 @@
   --color-selection: rgb(255 240 170);
   --color-notification: rgb(255 96 96);
   --margin: 1rem;
+  --line-height: 1.3;
+  --icon-size: calc(1rem * var(--line-height));
   --color-background-alpha: hsl(0deg 0% 97%);
   --color-background-beta: hsl(0deg 0% 94%);
 }
@@ -29,7 +31,7 @@ body {
   font-size: 16px;
   font-style: normal;
   font-weight: 500;
-  line-height: 1.3;
+  line-height: var(--line-height);
   color: var(--color-foreground);
   background-color: var(--color-background);
 }

--- a/components/UI/CopyToClipboard.js
+++ b/components/UI/CopyToClipboard.js
@@ -19,7 +19,7 @@ const CopyToClipboard = ({ content, title }) => {
         <TextButton title={title || t('Copy link to clipboard')} onClick={copyToClipboard}>
             { wasContentCopied ?
                 '✓':
-                <ClipboardIcon width="24" height="24" fill="var(--color-fg)" /> }
+                <ClipboardIcon width="var(--icon-size)" height="var(--icon-size)" fill="var(--color-fg)" /> }
         </TextButton>
     );
 };

--- a/components/UI/ServiceSubmenu.js
+++ b/components/UI/ServiceSubmenu.js
@@ -12,7 +12,7 @@ const Header = styled.header`
 const ToggleButton = styled.button`
   /* unset globally defined button styles; set height to line-height */
   width: unset;
-  height: calc(var(--margin) * 1.3);
+  height: calc(var(--margin) * var(--line-height));
   padding: unset;
   background-color: unset;
   border: unset;
@@ -54,7 +54,7 @@ export function ServiceSubmenu({ title, icon, subheadline, items, disabled }) {
             <Header>
                 { title && title }
                 { !disabled && <ToggleButton onClick={handleMenuToggle}>
-                    { icon ? icon : <MenuAddIcon width="24" height="24" fill="var(--color-foreground)" /> }
+                    { icon ? icon : <MenuAddIcon width="var(--icon-size)" height="var(--icon-size)" fill="var(--color-foreground)" /> }
                 </ToggleButton> }
             </Header>
             { isOpen && (

--- a/components/layouts/_base.js
+++ b/components/layouts/_base.js
@@ -55,7 +55,7 @@ const Header = styled.header`
 const ToggleButton = styled.button`
   /* unset globally defined button styles; set height to line-height */
   width: unset;
-  height: calc(var(--margin) * 1.3);
+  height: calc(var(--margin) * var(--line-height));
   padding: unset;
   background-color: unset;
   border: unset;
@@ -119,11 +119,11 @@ export default function BaseLayout({ children }) {
                     <h1>{ getConfig().publicRuntimeConfig.name ?? 'medienhaus/' }</h1>
                     { isNavigationOpen ? (
                         <ToggleButton onClick={() => { setIsNavigationOpen(false); }}>
-                            <CloseIcon width="24" height="24" fill="var(--color-foreground)" />
+                            <CloseIcon width="var(--icon-size)" height="var(--icon-size)" fill="var(--color-foreground)" />
                         </ToggleButton>
                     ) : (
                         <ToggleButton onClick={() => { setIsNavigationOpen(true); }}>
-                            <MenuIcon width="24" height="24" fill="var(--color-foreground)" />
+                            <MenuIcon width="var(--icon-size)" height="var(--icon-size)" fill="var(--color-foreground)" />
                         </ToggleButton>
                     ) }
                 </Header>

--- a/components/layouts/partials/languageChooser.js
+++ b/components/layouts/partials/languageChooser.js
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 const LanguageSelect = styled.select`
   display: inline;
   width: unset;
-  height: 1.3rem;
+  height: calc(1rem * var(--line-height));
   padding-left: 1ch;
   margin-bottom: 0;
   background-color: unset;

--- a/pages/account.js
+++ b/pages/account.js
@@ -11,7 +11,7 @@ import ConfirmCancelButtons from '../components/UI/ConfirmCancelButtons';
 const ProfileSection = styled.div`
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: calc(var(--margin) * 1.3);
+  grid-gap: calc(var(--margin) * var(--line-height));
   max-width: 55ch;
 
   & > form {
@@ -20,7 +20,7 @@ const ProfileSection = styled.div`
   }
 
   & > form > * + * {
-    margin-top: calc(var(--margin) * 1.3);
+    margin-top: calc(var(--margin) * var(--line-height));
   }
 
   @media (min-width: 40em) {
@@ -57,7 +57,7 @@ const Avatar = styled.img`
 
 const AvatarButtonContainer = styled.div`
   display: grid;
-  grid-gap: calc(var(--margin) * 1.3);
+  grid-gap: calc(var(--margin) * var(--line-height));
 
   @media (min-width: 40em) {
     grid-template-columns: repeat(auto-fit, minmax(calc(50% - (var(--margin) * 0.65)), 1fr));

--- a/pages/dashboard/DisplayInvitations.js
+++ b/pages/dashboard/DisplayInvitations.js
@@ -75,12 +75,12 @@ export default function DisplayInvitations({ invite, path, acceptMatrixInvite, d
             </ServiceTable.Cell>
             <ServiceTable.Cell title={t('accept invitation')}>
                 <TextButton onClick={(e) => { handleAccept(e, invite.roomId); }} disabled={isDecliningInvite || isAcceptingInvite || wasHandled}>
-                    { isAcceptingInvite ? <LoadingSpinnerInline /> : <CheckIcon width="24" height="24" /> }
+                    { isAcceptingInvite ? <LoadingSpinnerInline /> : <CheckIcon width="var(--icon-size)" height="var(--icon-size)" /> }
                 </TextButton>
             </ServiceTable.Cell>
             <ServiceTable.Cell title={t('decline invitation')}>
                 <TextButton onClick={(e) => {handleDecline(e, invite.roomId);}} disabled={isDecliningInvite || isAcceptingInvite || wasHandled}>
-                    { isDecliningInvite ? <LoadingSpinnerInline /> : <CloseIcon width="24" height="24" /> }
+                    { isDecliningInvite ? <LoadingSpinnerInline /> : <CloseIcon width="var(--icon-size)" height="var(--icon-size)" /> }
                 </TextButton>
             </ServiceTable.Cell>
         </ServiceTable.Row>

--- a/pages/etherpad/[[...roomId]].js
+++ b/pages/etherpad/[[...roomId]].js
@@ -232,12 +232,12 @@ export default function Etherpad() {
                         <h2>{ matrix.rooms.get(roomId).name }</h2>
                         <IframeLayout.IframeHeaderButtonWrapper>
                             <TextButton title={t('Invite users to' + ' ' + matrix.rooms.get(roomId).name)} onClick={() => setIsInviteUsersOpen(prevState => !prevState)}>
-                                { isInviteUsersOpen ? <UserUnfollowIcon width="24" height="24" fill="var(--color-foreground)" /> : <UserAddIcon width="24" height="24" fill="var(--color-foreground)" /> }
+                                { isInviteUsersOpen ? <UserUnfollowIcon width="var(--icon-size)" height="var(--icon-size)" fill="var(--color-foreground)" /> : <UserAddIcon width="var(--icon-size)" height="var(--icon-size)" fill="var(--color-foreground)" /> }
                             </TextButton>
 
                             <CopyToClipboard title={t('Copy pad link to clipboard')} content={matrix.roomContents.get(roomId)?.body} />
                             <TextButton title={t(mypadsPadObject ? 'Delete pad' : 'Remove pad from my library')} onClick={deletePad}>
-                                { isDeletingPad ? <LoadingSpinnerInline /> : <DeleteBinIcon width="24" height="24" fill="var(--color-foreground)" /> }
+                                { isDeletingPad ? <LoadingSpinnerInline /> : <DeleteBinIcon width="var(--icon-size)" height="var(--icon-size)" fill="var(--color-foreground)" /> }
                             </TextButton>
                         </IframeLayout.IframeHeaderButtonWrapper>
                     </IframeLayout.IframeHeader>

--- a/pages/spacedeck/[[...roomId]].js
+++ b/pages/spacedeck/[[...roomId]].js
@@ -221,7 +221,7 @@ export default function Spacedeck() {
                             <InviteUserToMatrixRoom roomId={roomId} roomName={matrix.rooms.get(roomId).name} />
                             <CopyToClipboard title={t('Copy sketch link to clipboard')} content={content.body} />
                             <TextButton title={t('Delete sketch')} onClick={removeSketch}>
-                                { isDeletingSketch ? <LoadingSpinnerInline /> : <DeleteBinIcon width="24" height="24" fill="var(--color-foreground)" /> }
+                                { isDeletingSketch ? <LoadingSpinnerInline /> : <DeleteBinIcon width="var(--icon-size)" height="var(--icon-size)" fill="var(--color-foreground)" /> }
                             </TextButton>
                         </IframeLayout.IframeHeaderButtonWrapper>
                     </IframeLayout.IframeHeader>


### PR DESCRIPTION
Introducing `var(--line-height)` instead of calculating with the literal value `1.3` in quite some occasions.

Also introducing `var(--icon-size)` as we don’t want to use static sizing of `24px` for `.svg` icons.

`var(--icon-size)` is being calculated by multiplying the root `font-size` × `var(--line-height)`, which makes `.svg` icons scale nicely relative to our `font-size` … or optionally the user-defined `font-size` via browser preferences. ✨