### PR TITLE
Use `default_room_version` from synapse when creating new rooms/spaces

### DIFF
--- a/lib/auth/MatrixAuthProvider.js
+++ b/lib/auth/MatrixAuthProvider.js
@@ -105,7 +105,6 @@ class MatrixAuthProvider {
     async createRoom(name, isSpace, topic, joinRule, type, template) {
         const opts = {
             name: name,
-            room_version: '9',
             preset: 'private_chat',
             topic: topic,
             visibility: 'private', // by default we want rooms and spaces to be private, this can later be changed either in /content or /moderate


### PR DESCRIPTION
Omit room version when creating rooms/spaces, to use latest version from server.