### PR TITLE
chore: refinements for `/account`

### DIFF
--- a/pages/account.js
+++ b/pages/account.js
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import getConfig from 'next/config';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { filter, map } from 'lodash';
 import styled from 'styled-components';
 
@@ -9,22 +9,29 @@ import { useAuth } from '../lib/Auth';
 import ConfirmCancelButtons from '../components/UI/ConfirmCancelButtons';
 import DefaultLayout from '../components/layouts/default';
 
+const AccountSection = styled(DefaultLayout.LameColumn)`
+  > * + *,
+  > form > * + * {
+    margin-top: var(--margin);
+  }
+`;
+
 const ProfileSection = styled.div`
   display: grid;
   grid-template-columns: max-content 1fr;
-  grid-gap: calc(var(--margin) * var(--line-height));
+  grid-gap: var(--margin);
 
-  & > form {
+  > form {
     grid-row: 2 / 3;
     grid-column: 1 / -1;
   }
 
-  & > form > * + * {
-    margin-top: calc(var(--margin) * var(--line-height));
+  > form > * + * {
+    margin-top: var(--margin);
   }
 
   @media (min-width: 40em) {
-    & > form {
+    > form {
       grid-row: 2 / 3;
       grid-column: 2;
     }
@@ -38,13 +45,6 @@ const Avatar = styled.img`
   width: calc(var(--margin) * 7.3);
   aspect-ratio: 1;
 
-  /*
-  background: var(--color-foreground);
-  border-color: var(--color-foreground);
-  border-style: solid;
-  border-width: calc(var(--margin) * 0.2);
-  */
-
   &.placeholder {
     backdrop-filter: invert(100%);
   }
@@ -57,7 +57,7 @@ const Avatar = styled.img`
 
 const AvatarButtonContainer = styled.div`
   display: grid;
-  grid-gap: calc(var(--margin) * var(--line-height));
+  grid-gap: var(--margin);
 
   @media (min-width: 40em) {
     grid-template-columns: repeat(auto-fit, minmax(calc(50% - (var(--margin) * 0.65)), 1fr));
@@ -200,22 +200,27 @@ export default function Account() {
 
     if (hasToConfirmNewEmail) {
         return (
-            <>
+            <AccountSection>
                 <h2>/account</h2>
                 <p>{ t('Please enter your account password to confirm adding the given email address:') }</p>
-                <br />
                 <form onSubmit={(event) => { event.preventDefault(); confirmNewEmail(); }} onReset={() => setInputPassword('')}>
                     <input type="password" placeholder={t('Password')} onChange={(event) => { setInputPassword(event.target.value);}} />
                     <ConfirmCancelButtons disabled={isSavingChanges} />
                 </form>
                 { feedbackMessage && (<p>❗️ { feedbackMessage }</p>) }
-            </>
+            </AccountSection>
         );
     }
 
     return (
-        <DefaultLayout.LameColumn>
+        <AccountSection>
             <h2>/account</h2>
+            <Trans
+                t={t}
+                i18nKey="introduction"
+                defaults="Here you can modify your display name and profile image, which might be shared with other accounts when, for example, interacting with them via <bold>/chat</bold>, <bold>/write</bold>, or <bold>/sketch</bold>."
+                components={{ bold: <strong /> }}
+            />
             <ProfileSection>
                 { profileInfo.avatar_url ? (
                     // Render the avatar if we have one
@@ -260,6 +265,6 @@ export default function Account() {
                     { feedbackMessage && (<p>❗️ { feedbackMessage }</p>) }
                 </form>
             </ProfileSection>
-        </DefaultLayout.LameColumn>
+        </AccountSection>
     );
 }

--- a/pages/account.js
+++ b/pages/account.js
@@ -10,7 +10,16 @@ import ConfirmCancelButtons from '../components/UI/ConfirmCancelButtons';
 import DefaultLayout from '../components/layouts/default';
 
 const AccountSection = styled(DefaultLayout.LameColumn)`
-  > * + *,
+  /* TODO: these kind of layout spacings probably need to
+   * be refined across all pages once merged into main */
+  > * + * {
+    margin-top: calc(var(--margin) * 1.5);
+
+    @media (min-width: 1080px) {
+      margin-top: calc(var(--margin) * 2.5);
+    }
+  }
+
   > form > * + * {
     margin-top: var(--margin);
   }

--- a/public/locales/de/_defaults.json
+++ b/public/locales/de/_defaults.json
@@ -10,7 +10,7 @@
   "Password": "Passwort",
   "password protected": "Passwortgeschützt",
   "Upload": "Hochladen",
-  "Save changes": "Änderungen speichern",
+  "Save": "Speichern",
   "Select action": "Aktion wählen",
   "What would you like to do?": "Was möchtest Du tun?",
   "{{error}}, please wait {{time}} seconds.": "{{error}}, bitte warte {{time}} Sekunden.",

--- a/public/locales/de/account.json
+++ b/public/locales/de/account.json
@@ -1,4 +1,5 @@
 {
+  "introduction": "Hier können Anzeigename und Profilbild geändert werden; beides ist beim Interagieren mit anderen Accounts, zum Beispiel via <bold>/chat</bold>, <bold>/write</bold>, oder <bold>/sketch</bold> für andere Accounts sichtbar.",
   "We have sent a confirmation email to the provided address.": "Wir haben eine Bestätigungs-E-Mail an eingegebene Adresse gesendet.",
   "Please enter your account password to confirm adding the given email address:": "Bitte bestätige das Hinzufügen der eingegebenen E-Mail-Adresse mit deinem Passwort:",
   "add another email address": "weitere E-Mail-Adressen hinzufügen",


### PR DESCRIPTION
Changing some wording, and refining the styled components CSS a little bit.

@fnwbr As you’re probably going to like this, I introduced some breakpoint-respecting layout spacing for just this route; as the [comment](https://github.com/medienhaus/medienhaus-spaces/pull/101/commits/2ac047c1a552d3fcd3d72a165f26f79731a76850#diff-6884e7de2e61c2a128e0cff4b29a2f834315f11c91f478f58fcb72fcbcb5c77eR13-R14) states, these kind of layout spacings need to be revised across all routes and components once merged into `main`.

Feel free to adapt/change and merge as you please. ✨