### PR TITLE
draft: layout changes for `/account` route

### DIFF
--- a/assets/_globalCss.css
+++ b/assets/_globalCss.css
@@ -117,7 +117,7 @@ select {
   border-color: var(--color-foreground);
   border-style: solid;
   border-width: calc(var(--margin) * 0.2);
-  border-radius: unset;
+  border-radius: var(--border-radius);
   appearance: none;
 }
 
@@ -184,7 +184,7 @@ input[type='url'] {
   border-color: var(--color-foreground);
   border-style: solid;
   border-width: calc(var(--margin) * 0.2);
-  border-radius: unset;
+  border-radius: var(--border-radius);
   appearance: none;
 }
 

--- a/components/layouts/default.js
+++ b/components/layouts/default.js
@@ -26,11 +26,9 @@ const LameColumn = styled.div`
     padding: calc(var(--margin) * 2) calc(var(--margin) * 1.5);
   }
 
-  /* NOTE: force-add some padding below very last element
-   * TODO: these kind of layout spacings probably need to
-   * be refined across all pages once merged into main */
+  /* force-add some whitespace at the bottom of our LameColumn's contents */
   > :last-child {
-    padding-bottom: calc(var(--margin) * 3);
+    margin-bottom: calc(var(--margin) * 3);
   }
 `;
 

--- a/components/layouts/default.js
+++ b/components/layouts/default.js
@@ -8,6 +8,7 @@ export const Main = styled.main`
   display: flex;
   flex: 1 0;
   flex-direction: column;
+  overflow-y: auto;
 
   @media ${breakpoints.tabletAndAbove} {
     flex-direction: row;
@@ -23,6 +24,13 @@ const LameColumn = styled.div`
     width: 100%;
     max-width: 55ch;
     padding: calc(var(--margin) * 2) calc(var(--margin) * 1.5);
+  }
+
+  /* NOTE: force-add some padding below very last element
+   * TODO: these kind of layout spacings probably need to
+   * be refined across all pages once merged into main */
+  > :last-child {
+    padding-bottom: calc(var(--margin) * 3);
   }
 `;
 

--- a/components/layouts/default.js
+++ b/components/layouts/default.js
@@ -8,12 +8,12 @@ export const Main = styled.main`
   display: flex;
   flex: 1 0;
   flex-direction: column;
-  overflow-y: auto;
 
   @media ${breakpoints.tabletAndAbove} {
     flex-direction: row;
     grid-row: 1/4;
     grid-column: 2;
+    overflow-y: auto;
   }
 `;
 

--- a/pages/account.js
+++ b/pages/account.js
@@ -12,66 +12,55 @@ import DefaultLayout from '../components/layouts/default';
 const AccountSection = styled(DefaultLayout.LameColumn)`
   /* TODO: these kind of layout spacings probably need to
    * be refined across all pages once merged into main */
-  > * + * {
-    margin-top: calc(var(--margin) * 1.5);
 
-    @media (min-width: 1080px) {
-      margin-top: calc(var(--margin) * 2.5);
-    }
+  > * + * {
+    margin-top: calc(var(--margin) * var(--line-height) * 2);
   }
 
-  > form > * + * {
-    margin-top: var(--margin);
+  > * > * + * {
+    margin-top: calc(var(--margin) * var(--line-height));
+  }
+
+  /* NOTE: selector for the email confirmation page form */
+  form {
+    > * + * {
+      margin-top: var(--margin);
+    }
   }
 `;
 
-const ProfileSection = styled.div`
+const AvatarSection = styled.div`
   display: grid;
-  grid-template-columns: max-content 1fr;
+  grid-auto-flow: row;
   grid-gap: var(--margin);
 
-  > form {
-    grid-row: 2 / 3;
-    grid-column: 1 / -1;
-  }
-
-  > form > * + * {
-    margin-top: var(--margin);
-  }
-
   @media (min-width: 40em) {
-    > form {
-      grid-row: 2 / 3;
-      grid-column: 2;
-    }
+    grid-template-columns: 1fr 1fr;
   }
 `;
 
 const Avatar = styled.img`
-  display: block;
-  grid-row: 1 / 2;
-  grid-column: 1;
-  width: calc(var(--margin) * 7.3);
-  aspect-ratio: 1;
+  width: 50%;
 
   &.placeholder {
     backdrop-filter: invert(100%);
   }
 
   @media (min-width: 40em) {
-    grid-row: 1 / 3;
-    width: calc(var(--margin) * 11.6);
+    width: 70%;
   }
 `;
 
 const AvatarButtonContainer = styled.div`
   display: grid;
+  grid-auto-flow: row;
   grid-gap: var(--margin);
+  align-content: start;
+`;
 
-  @media (min-width: 40em) {
-    grid-template-columns: repeat(auto-fit, minmax(calc(50% - (var(--margin) * 0.65)), 1fr));
-    grid-row: 1;
-    grid-column: 2;
+const ProfileSection = styled.form`
+  > * + * {
+    margin-top: var(--margin);
   }
 `;
 
@@ -210,42 +199,54 @@ export default function Account() {
     if (hasToConfirmNewEmail) {
         return (
             <AccountSection>
-                <h2>/account</h2>
-                <p>{ t('Please enter your account password to confirm adding the given email address:') }</p>
-                <form onSubmit={(event) => { event.preventDefault(); confirmNewEmail(); }} onReset={() => setInputPassword('')}>
-                    <input type="password" placeholder={t('Password')} onChange={(event) => { setInputPassword(event.target.value);}} />
-                    <ConfirmCancelButtons disabled={isSavingChanges} />
-                </form>
-                { feedbackMessage && (<p>❗️ { feedbackMessage }</p>) }
+                <div>
+                    <h2>/account</h2>
+                    <p>{ t('Please enter your account password to confirm adding the given email address:') }</p>
+                    <form onSubmit={(event) => { event.preventDefault(); confirmNewEmail(); }} onReset={() => setInputPassword('')}>
+                        <input type="password" placeholder={t('Password')} onChange={(event) => { setInputPassword(event.target.value);}} />
+                        <ConfirmCancelButtons disabled={isSavingChanges} />
+                    </form>
+                    { feedbackMessage && (<p>❗️ { feedbackMessage }</p>) }
+                </div>
             </AccountSection>
         );
     }
 
     return (
         <AccountSection>
-            <h2>/account</h2>
-            <Trans
-                t={t}
-                i18nKey="introduction"
-                defaults="Here you can modify your display name and profile image, which might be shared with other accounts when, for example, interacting with them via <bold>/chat</bold>, <bold>/write</bold>, or <bold>/sketch</bold>."
-                components={{ bold: <strong /> }}
-            />
-            <ProfileSection>
-                { profileInfo.avatar_url ? (
+            <div>
+                <h2>/account</h2>
+                <p>
+                    <Trans
+                        t={t}
+                        i18nKey="introduction"
+                        defaults="Here you can modify your display name and profile image, which might be shared with other accounts when, for example, interacting with them via <bold>/chat</bold>, <bold>/write</bold>, or <bold>/sketch</bold>."
+                        components={{ bold: <strong /> }}
+                    />
+                </p>
+            </div>
+            <div>
+                <h3>{ t('Avatar — Profile Image') }</h3>
+                <AvatarSection>
+                    { profileInfo.avatar_url ? (
                     // Render the avatar if we have one
-                    <Avatar src={matrixClient.mxcUrlToHttp(profileInfo.avatar_url, 500, 500, 'crop')} />
-                ) : (
+                        <Avatar src={matrixClient.mxcUrlToHttp(profileInfo.avatar_url, 500, 500, 'crop')} />
+                    ) : (
                     // Render an empty GIF if we don't have an avatar
-                    <Avatar className="placeholder" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" />
-                ) }
-                <AvatarButtonContainer>
-                    <input type="file" onChange={uploadAvatar} ref={avatarFileUploadInput} style={{ display: 'none' }} accept="image/*" />
-                    <button type="button" disabled={isChangingAvatar} onClick={() => { avatarFileUploadInput.current.click(); }}>{ t('Upload') } …</button>
-                    { profileInfo.avatar_url && (
-                        <button type="button" disabled={isChangingAvatar} onClick={deleteAvatar}>{ t('Delete') }</button>
+                        <Avatar className="placeholder" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" />
                     ) }
-                </AvatarButtonContainer>
-                <form onSubmit={(e) => { e.preventDefault(); saveChanges(); }} onReset={handleCancel}>
+                    <AvatarButtonContainer>
+                        <input type="file" onChange={uploadAvatar} ref={avatarFileUploadInput} style={{ display: 'none' }} accept="image/*" />
+                        <button type="button" disabled={isChangingAvatar} onClick={() => { avatarFileUploadInput.current.click(); }}>{ t('Browse') } …</button>
+                        { profileInfo.avatar_url && (
+                            <button type="button" disabled={isChangingAvatar} onClick={deleteAvatar}>{ t('Delete') }</button>
+                        ) }
+                    </AvatarButtonContainer>
+                </AvatarSection>
+            </div>
+            <div>
+                <h3>{ t('Display Name & Email Addresses') }</h3>
+                <ProfileSection onSubmit={(e) => { e.preventDefault(); saveChanges(); }} onReset={handleCancel}>
                     <input
                         type="text"
                         value={inputDisplayname}
@@ -253,6 +254,11 @@ export default function Account() {
                         placeholder={matrixClient.getUserId()}
                         onChange={(event) => { setInputDisplayname(event.target.value); }}
                     />
+                    { (
+                        profileInfo.displayname !== inputDisplayname
+                    ) && (
+                        <ConfirmCancelButtons disabled={isSavingChanges}>{ t('Save') }</ConfirmCancelButtons>
+                    ) }
                     { emails.map((email, index) => (
                         <input key={email} type="email" value={email} disabled />
                     )) }
@@ -266,14 +272,13 @@ export default function Account() {
                         />
                     ) }
                     { (
-                        profileInfo.displayname !== inputDisplayname ||
                         inputNewEmail
                     ) && (
-                        <ConfirmCancelButtons disabled={isSavingChanges}>{ t('Save changes') }</ConfirmCancelButtons>
+                        <ConfirmCancelButtons disabled={isSavingChanges}>{ t('Save') }</ConfirmCancelButtons>
                     ) }
                     { feedbackMessage && (<p>❗️ { feedbackMessage }</p>) }
-                </form>
-            </ProfileSection>
+                </ProfileSection>
+            </div>
         </AccountSection>
     );
 }

--- a/pages/chat/[[...roomId]].js
+++ b/pages/chat/[[...roomId]].js
@@ -104,9 +104,8 @@ export default function Chat() {
                     --cpd-avatar-color: #ffffff !important;
                     --cpd-color-text-action-accent: #000 !important;
                     --color-foreground-alpha: rgb(0 0 0 / 5%);
-                    
-                    /* You know why... */
-                    border-radius: unset !important;
+
+                    border-radius: 4px !important;
                 }
                 
                 @media (prefers-color-scheme: dark) {

--- a/public/locales/de/account.json
+++ b/public/locales/de/account.json
@@ -2,6 +2,9 @@
   "introduction": "Hier können Anzeigename und Profilbild geändert werden; beides ist beim Interagieren mit anderen Accounts, zum Beispiel via <bold>/chat</bold>, <bold>/write</bold>, oder <bold>/sketch</bold> für andere Accounts sichtbar.",
   "We have sent a confirmation email to the provided address.": "Wir haben eine Bestätigungs-E-Mail an eingegebene Adresse gesendet.",
   "Please enter your account password to confirm adding the given email address:": "Bitte bestätige das Hinzufügen der eingegebenen E-Mail-Adresse mit deinem Passwort:",
+  "Avatar — Profile Image": "Avatar — Profilbild",
+  "Display Name & Email Addresses": "Anzeigename & E-Mail-Adressen",
+  "Browse": "Durchsuchen",
   "add another email address": "weitere E-Mail-Adressen hinzufügen",
   "add your email address": "E-Mail-Adresse hinzufügen"
 }


### PR DESCRIPTION
@fnwbr Still needs some refinements here and there, and I’m not sure if adding the bottom padding to the `LameColumn` this way is a nice solution; maybe you know how to improve this within the surrounding/wrapping flexbox `main` element. Also you might want to change the amount of bottom padding in regards to the viewport breakpoint `@media` query.

<img width="1192" alt="Screenshot 2023-11-28 at 18 19 41" src="https://github.com/medienhaus/medienhaus-spaces/assets/63073125/f27eaaf7-02b2-41ed-951d-8096eda95d33">

<img width="1148" alt="Screenshot 2023-11-28 at 18 19 52" src="https://github.com/medienhaus/medienhaus-spaces/assets/63073125/62d5bcdb-bb74-4f70-942f-200d0bb82c9f">

<img width="1192" alt="Screenshot 2023-11-28 at 18 20 33" src="https://github.com/medienhaus/medienhaus-spaces/assets/63073125/39ce1654-8c0f-43ea-9e78-9be9b98bced0">

<img width="1148" alt="Screenshot 2023-11-28 at 18 20 43" src="https://github.com/medienhaus/medienhaus-spaces/assets/63073125/40f503b8-7d9b-49c0-88c9-632fe2ba6e3f">
