### PR TITLE
Create `m.space.parent` when creating new rooms (with parent)

### DIFF
--- a/lib/Matrix.js
+++ b/lib/Matrix.js
@@ -188,8 +188,8 @@ function useMatrixProvider(auth) {
         };
     }, [AccountDataEvent, RoomMyMembershipEvent, RoomReceiptEvent, RoomTimelineEvent, SyncEvent, matrixClient]);
 
-    const createRoom = useCallback(async (name, isSpace, topic, joinRule, type, template, application) => {
-        const room = await authenticationProvider.createRoom(name, isSpace, topic, joinRule, type, template, application);
+    const createRoom = useCallback(async (name, isSpace, topic, joinRule, type, template, parentId) => {
+        const room = await authenticationProvider.createRoom(name, isSpace, topic, joinRule, type, template, parentId);
 
         if (isSpace) {
             if (!spaces.has(room.room_id)) {
@@ -267,7 +267,9 @@ function useMatrixProvider(auth) {
                         `This is your private space for the application ${element}. You can find all your ${element} data in here.`,
                         'invite',
                         'context',
-                        'application');
+                        'application',
+                        applicationsFolder,
+                    );
                     logger.debug('Created new service space...', { serviceType: element, roomId });
                     await authenticationProvider.addSpaceChild(applicationsFolder, roomId);
                     setServiceSpaces(object => { object[element] = roomId; });

--- a/lib/auth/MatrixAuthProvider.js
+++ b/lib/auth/MatrixAuthProvider.js
@@ -133,6 +133,8 @@ class MatrixAuthProvider {
                 content: { join_rule: joinRule }, // can be set to either public, invite or knock
             },
             {
+                // Spec: https://spec.matrix.org/v1.9/client-server-api/#mspaceparent
+                // Element-Web: https://github.com/matrix-org/matrix-react-sdk/blob/fb1a97be3228ce1341c54a379f8374710b65a0e8/src/utils/space.tsx#L51-L58
                 type: 'm.space.parent',
                 state_key: parentId,
                 content: {

--- a/lib/auth/MatrixAuthProvider.js
+++ b/lib/auth/MatrixAuthProvider.js
@@ -102,12 +102,25 @@ class MatrixAuthProvider {
         return this.matrixClient.getStateEvent(roomId, 'dev.medienhaus.meta');
     }
 
-    async createRoom(name, isSpace, topic, joinRule, type, template) {
+    /**
+     * Creates a new room or space in Matrix.
+     *
+     * @param {string} name - The name of the room or space.
+     * @param {boolean} isSpace - Whether the room is a space.
+     * @param {string} topic - The topic of the room or space.
+     * @param {string} joinRule - The join rule for the room or space. Can be 'public', 'invite', or 'knock'.
+     * @param {string} type - The type of the room or space.
+     * @param {string} template - The template for the room or space.
+     * @param {string} parentId - The ID of the parent space, if any.
+     * @returns {Promise<Object>} A promise that resolves to the created room or space.
+     * @throws {Error} If there was an error creating the room or space.
+     */
+    async createRoom(name, isSpace, topic, joinRule, type, template, parentId) {
         const opts = {
             name: name,
             preset: 'private_chat',
             topic: topic,
-            visibility: 'private', // by default we want rooms and spaces to be private, this can later be changed either in /content or /moderate
+            visibility: 'private', // by default, we want rooms and spaces to be private, this can later be changed either in /content or /moderate
             creation_content: {
                 type: isSpace ? 'm.space' : 'm.room',
             },
@@ -118,7 +131,16 @@ class MatrixAuthProvider {
             {
                 type: 'm.room.join_rules',
                 content: { join_rule: joinRule }, // can be set to either public, invite or knock
-            }],
+            },
+            {
+                type: 'm.space.parent',
+                state_key: parentId,
+                content: {
+                    canonical: true,
+                    via: [this.matrixClient.getDomain()],
+                },
+            },
+            ],
             power_level_content_override: {
                 // we only want users with moderation rights to be able to do any actions, people joining the room will have a default level of 0.
                 ban: 50,

--- a/pages/dashboard/index.js
+++ b/pages/dashboard/index.js
@@ -106,7 +106,6 @@ export default function Dashboard() {
                     }) }
                 </>
             }
-            { /* show pending knocks here */ }
         </DefaultLayout.LameColumn>
     );
 }

--- a/pages/dashboard/index.js
+++ b/pages/dashboard/index.js
@@ -106,6 +106,7 @@ export default function Dashboard() {
                     }) }
                 </>
             }
+            { /* show pending knocks here */ }
         </DefaultLayout.LameColumn>
     );
 }

--- a/pages/etherpad/[[...roomId]].js
+++ b/pages/etherpad/[[...roomId]].js
@@ -140,7 +140,7 @@ export default function Etherpad() {
 
         logger.debug('Creating new Matrix room for pad', { link, name });
 
-        const room = await matrix.createRoom(name, false, '', 'invite', 'content', 'etherpad');
+        const room = await matrix.createRoom(name, false, '', 'invite', 'content', 'etherpad', matrix.serviceSpaces.etherpad);
         await auth.getAuthenticationProvider('matrix').addSpaceChild(matrix.serviceSpaces.etherpad, room);
         await matrixClient.sendMessage(room, {
             msgtype: 'm.text',

--- a/pages/spacedeck/[[...roomId]].js
+++ b/pages/spacedeck/[[...roomId]].js
@@ -153,7 +153,7 @@ export default function Spacedeck() {
     async function createSketchRoom(link, name, parent = serviceSpaceId) {
         // eslint-disable-next-line no-undef
         logger.debug('creating room for ' + name);
-        const room = await matrix.createRoom(name, false, '', 'invite', 'content', 'spacedeck').catch(() => {
+        const room = await matrix.createRoom(name, false, '', 'invite', 'content', 'spacedeck', parent).catch(() => {
             setErrorMessage(t('Something went wrong when trying to create a new room'));
         });
         await auth.getAuthenticationProvider('matrix').addSpaceChild(parent, room).catch(() => {


### PR DESCRIPTION
adds [m.space.parent](https://spec.matrix.org/v1.9/client-server-api/#mspaceparent) event when a parent room id is parsed.
`canocical` is set to true, since rooms are newly created, therfore we can assume the parsed parent id is the is the primary parent.
