### PR TITLE
/chat: Use Element "home screen" to create new chats

### DIFF
--- a/pages/chat/[[...roomId]].js
+++ b/pages/chat/[[...roomId]].js
@@ -149,7 +149,20 @@ export default function Chat() {
                     .mx_RoomView_timeline_rr_enabled .mx_EventTile[data-layout=group] .mx_EventTile_line,
                     .mx_RoomView_timeline_rr_enabled .mx_EventTile[data-layout=group] .mx_ThreadSummary,
                     .mx_RoomView_timeline_rr_enabled .mx_EventTile[data-layout=group] .mx_ThreadSummary_icon { margin-right: unset; }
+                    
+                    /* Make all Element modal dialogs span across the whole screen; this also affects dialogs on the "new chat" home screen */ 
+                    .mx_Dialog { position: absolute; top: 0; left: 0; right: 0; bottom: 0; max-height: unset !important; border-radius: 0 !important; }
+                    .mx_Dialog_fixedWidth { width: 100% !important; max-width: unset !important; }
                 }
+
+                /**
+                 * ===================== Element Home Screen (the one we use to create new chats) =====================
+                 */
+                /* Don't display the "explore public rooms" button */
+                .mx_HomePage_button_explore { display: none !important }
+                .mx_HomePage_default_buttons { display: initial !important }
+                /* Don't display Element welcome message */
+                .mx_HomePage_default_wrapper > div:first-child { display: none }
             `);
             styleTag.appendChild(styleContent);
             iframeReference.contentDocument.getElementsByTagName('html')[0].appendChild(styleTag);


### PR DESCRIPTION
This basically supersedes and replaces https://github.com/medienhaus/medienhaus-spaces/pull/38 -- and does everything we want (see screenshots below).
Navigation on mobile is supported just like we do it for `/write` or `/sketch`: use your "back" button (or swipe on mobile devices) to go back to the previous page.

<img width="1645" alt="image" src="https://github.com/medienhaus/medienhaus-spaces/assets/706419/b55a4732-e9a4-4dc2-931b-6b4b90b84fed">


| | |
| ------------- | ------------- |
| ![Screen Shot 2023-12-06 at 15 15 01](https://github.com/medienhaus/medienhaus-spaces/assets/706419/4aaa9b18-5f1f-4939-bb96-6357b27799fb) | ![Screen Shot 2023-12-06 at 15 14 56](https://github.com/medienhaus/medienhaus-spaces/assets/706419/3bd8432b-96d3-4402-a05c-2cc1bb0b26cc) |
