### PR TITLE
{=> accept-knocks} Re-structure how we manage the internal state of `pendingKnocks`/`knockingMembers`

### DIFF
--- a/lib/Matrix.js
+++ b/lib/Matrix.js
@@ -2,7 +2,7 @@ import { createContext, useCallback, useContext, useEffect, useState } from 'rea
 import getConfig from 'next/config';
 import _ from 'lodash';
 import { useImmer } from 'use-immer';
-import { ClientEvent, EventTimeline, RoomEvent } from 'matrix-js-sdk';
+import { ClientEvent, EventTimeline, EventType, RoomEvent } from 'matrix-js-sdk';
 
 import logger from './Logging';
 
@@ -175,12 +175,7 @@ function useMatrixProvider(auth) {
             // If this is a timeline event for a room that we're not a member of, we want to ignore it
             if (room.getMyMembership() !== 'join') return;
 
-            if (knockingMembers.has(room.roomId) && event.event.content.membership !== 'knock') {
-                setKnockingMembers(map => {
-                    map.delete(room.roomId);
-                });
-            }
-
+            // Update our room-typical stores (rooms, spaces, directMessages)
             if (directMessages.has(room.roomId)) {
                 setDirectMessages(setRoom(room.roomId));
             } else if (room.isSpaceRoom()) {
@@ -189,7 +184,32 @@ function useMatrixProvider(auth) {
                 setRooms(setRoom(room.roomId));
                 setRoomContents(setMessages(room.roomId));
             }
-        }, [directMessages, knockingMembers, setDirectMessages, setKnockingMembers, setMessages, setRoom, setRoomContents, setRooms, setSpaces],
+
+            // Update our internal store for pending knocks if this timeline event contained info about a knock
+            if (
+                event.getType() === EventType.RoomMember &&
+                room.getMember(matrixClient.getUserId()).powerLevel >= room.getLiveTimeline().getState(EventTimeline.FORWARDS).getStateEvents(EventType.RoomPowerLevels, '')?.getContent()['invite'] &&
+                event.getContent().membership === 'knock'
+            ) {
+                // Looks like we got a new knock for a room that we can manage them for ...
+                setKnockingMembers(map => {
+                    map.set(`${room.roomId}|${event.target.userId}`, {
+                        roomId: room.roomId,
+                        userId: event.target.userId,
+                        reason: event.getContent()?.reason,
+                    });
+                });
+            } else if (
+                event.getType() === EventType.RoomMember &&
+                knockingMembers.has(`${room.roomId}|${event.target.userId}`) &&
+                event.getContent().membership !== 'knock'
+            ) {
+                // Looks like some previously existing knock was handled (or retracted?) ...
+                setKnockingMembers(map => {
+                    map.delete(`${room.roomId}|${event.target.userId}`);
+                });
+            }
+        }, [directMessages, knockingMembers, matrixClient, setDirectMessages, setKnockingMembers, setMessages, setRoom, setRoomContents, setRooms, setSpaces],
     );
 
     const RoomReceiptEvent = useCallback(

--- a/lib/Matrix.js
+++ b/lib/Matrix.js
@@ -186,30 +186,25 @@ function useMatrixProvider(auth) {
             }
 
             // Update our internal store for pending knocks if this timeline event contained info about a knock
-            if (
-                event.getType() === EventType.RoomMember &&
-                room.getMember(matrixClient.getUserId()).powerLevel >= room.getLiveTimeline().getState(EventTimeline.FORWARDS).getStateEvents(EventType.RoomPowerLevels, '')?.getContent()['invite'] &&
-                event.getContent().membership === 'knock'
-            ) {
-                // Looks like we got a new knock for a room that we can manage them for ...
+            if (event.getType() === EventType.RoomMember) {
                 setKnockingMembers(map => {
-                    map.set(`${room.roomId}|${event.target.userId}`, {
-                        roomId: room.roomId,
-                        userId: event.target.userId,
-                        reason: event.getContent()?.reason,
-                    });
-                });
-            } else if (
-                event.getType() === EventType.RoomMember &&
-                knockingMembers.has(`${room.roomId}|${event.target.userId}`) &&
-                event.getContent().membership !== 'knock'
-            ) {
-                // Looks like some previously existing knock was handled (or retracted?) ...
-                setKnockingMembers(map => {
-                    map.delete(`${room.roomId}|${event.target.userId}`);
+                    if (
+                        room.getMember(matrixClient.getUserId()).powerLevel >= room.getLiveTimeline().getState(EventTimeline.FORWARDS).getStateEvents(EventType.RoomPowerLevels, '')?.getContent()['invite'] &&
+                        event.getContent().membership === 'knock'
+                    ) {
+                        // Looks like we got a new knock for a room that we can manage them for ...
+                        map.set(`${room.roomId}|${event.target.userId}`, {
+                            roomId: room.roomId,
+                            userId: event.target.userId,
+                            reason: event.getContent()?.reason,
+                        });
+                    } else if (map.has(`${room.roomId}|${event.target.userId}`)) {
+                        // Looks like some previously existing knock was handled (or retracted?) ...
+                        map.delete(`${room.roomId}|${event.target.userId}`);
+                    }
                 });
             }
-        }, [directMessages, knockingMembers, matrixClient, setDirectMessages, setKnockingMembers, setMessages, setRoom, setRoomContents, setRooms, setSpaces],
+        }, [directMessages, matrixClient, setDirectMessages, setKnockingMembers, setMessages, setRoom, setRoomContents, setRooms, setSpaces],
     );
 
     const RoomReceiptEvent = useCallback(

--- a/lib/Matrix.js
+++ b/lib/Matrix.js
@@ -45,19 +45,6 @@ function useMatrixProvider(auth) {
 
         const roomState = room.getLiveTimeline().getState(EventTimeline.FORWARDS);
 
-        // check if any users have knocked on the room
-        const knockingMembers = room.getMembersWithMembership('knock');
-
-        if (knockingMembers.length > 0) {
-            // if there are any knocking members, we add the name of the room to the object and add it to the state
-            knockingMembers.forEach((member) => {
-                member.roomName = room.name;
-            });
-            setKnockingMembers(map => {
-                map.set(roomId, ...knockingMembers);
-            });
-        }
-
         return {
             roomId,
             name: room.name,
@@ -66,7 +53,7 @@ function useMatrixProvider(auth) {
             notificationCount: room.getUnreadNotificationCount(),
             avatar,
         };
-    }, [matrixClient, setKnockingMembers]);
+    }, [matrixClient]);
 
     const setRoom = useCallback((roomId) => {
         return (map) => {
@@ -224,6 +211,27 @@ function useMatrixProvider(auth) {
         [directMessages, setDirectMessages, setMessages, setRoom, setRoomContents, setRooms],
     );
 
+    const initializePendingKnocks = useCallback(() => {
+        matrixClient.getRooms().forEach((room) => {
+            // If this is a room we're not part of then we do not care about pending knocks; return early
+            if (room.getMyMembership() !== 'join') return;
+            // If this is a room we don't have sufficient power levels to invite new people to, we also don't care about knocks
+            if (room.getMember(matrixClient.getUserId()).powerLevel < room.getLiveTimeline().getState(EventTimeline.FORWARDS).getStateEvents(EventType.RoomPowerLevels, '')?.getContent()['invite']) return;
+            // Before we update the state let's make sure there are actually pending knocks there; otherwise return early
+            if (room.getMembersWithMembership('knock').length < 1) return;
+
+            room.getMembersWithMembership('knock').forEach((roomMember) => {
+                setKnockingMembers(map => {
+                    map.set(`${room.roomId}|${roomMember.user?.userId}`, {
+                        roomId: room.roomId,
+                        userId: roomMember.user?.userId,
+                        reason: roomMember.events.member?.getContent()?.reason,
+                    });
+                });
+            });
+        });
+    }, [matrixClient, setKnockingMembers]);
+
     const SyncEvent = useCallback(
         /**
          * @param {string} newState One of "ERROR", "PREPARED", "STOPPED", "SYNCING", "CATCHUP" or "RECONNECTING"
@@ -236,6 +244,7 @@ function useMatrixProvider(auth) {
                 (async () => {
                     const mDirectEventContent = await matrixClient.getAccountDataFromServer('m.direct');
                     hydrateDirectMessages(mDirectEventContent);
+                    initializePendingKnocks();
                     setInitialSyncDone(true);
                 })();
             }
@@ -245,7 +254,7 @@ function useMatrixProvider(auth) {
                 setIsConnectedToServer(false);
             }
         },
-        [hydrateDirectMessages, matrixClient],
+        [hydrateDirectMessages, initializePendingKnocks, matrixClient],
     );
 
     useEffect(() => {

--- a/lib/Matrix.js
+++ b/lib/Matrix.js
@@ -185,24 +185,24 @@ function useMatrixProvider(auth) {
          * @param {Room} room
          */
         (event, room) => {
-        // If this is a timeline event for a room that we're not a member of, we want to ignore it
+            // If this is a timeline event for a room that we're not a member of, we want to ignore it
             if (room.getMyMembership() !== 'join') return;
 
             if (knockingMembers.has(room.roomId) && event.event.content.membership !== 'knock') {
-            setKnockingMembers(map => {
-                map.delete(room.roomId);
-            });
-        }
+                setKnockingMembers(map => {
+                    map.delete(room.roomId);
+                });
+            }
 
-        if (directMessages.has(room.roomId)) {
-            setDirectMessages(setRoom(room.roomId));
-        } else if (room.isSpaceRoom()) {
-            setSpaces(setRoom(room.roomId));
-        } else {
-            setRooms(setRoom(room.roomId));
-            setRoomContents(setMessages(room.roomId));
-        }
-    }, [directMessages, knockingMembers, setDirectMessages, setKnockingMembers, setMessages, setRoom, setRoomContents, setRooms, setSpaces],
+            if (directMessages.has(room.roomId)) {
+                setDirectMessages(setRoom(room.roomId));
+            } else if (room.isSpaceRoom()) {
+                setSpaces(setRoom(room.roomId));
+            } else {
+                setRooms(setRoom(room.roomId));
+                setRoomContents(setMessages(room.roomId));
+            }
+        }, [directMessages, knockingMembers, setDirectMessages, setKnockingMembers, setMessages, setRoom, setRoomContents, setRooms, setSpaces],
     );
 
     const RoomReceiptEvent = useCallback(

--- a/pages/dashboard/KnockCard.js
+++ b/pages/dashboard/KnockCard.js
@@ -17,9 +17,10 @@ const TextParagraph = styled.p`
  * @param {string} roomName - The name of the room where the knock request was made.
  * @param {string} user - The name of the user who made the knock request.
  * @param {string} userId - The ID of the user who made the knock request.
+ * @param {string} reason
  * @returns {JSX.Element} A form that allows the user to accept or decline the knock request.
  */
-export default function KnockCard({ roomId, roomName, user, userId }) {
+export default function KnockCard({ roomId, roomName, user, userId, reason }) {
     const auth = useAuth();
     const { t } = useTranslation('dashboard');
     const matrixClient = auth.getAuthenticationProvider('matrix').getMatrixClient();
@@ -56,6 +57,9 @@ export default function KnockCard({ roomId, roomName, user, userId }) {
                         components={{ bold: <strong /> }}
                     />
                 </TextParagraph>
+                { reason && (
+                    <pre>{ reason }</pre>
+                ) }
                 <ConfirmCancelButtons
                     small
                     disabled={isDecliningKnock || isAcceptingKnock}

--- a/pages/dashboard/KnockCard.js
+++ b/pages/dashboard/KnockCard.js
@@ -50,7 +50,7 @@ export default function KnockCard({ roomId, roomName, user, userId }) {
                 <TextParagraph>
                     <Trans
                         t={t}
-                        i18nKey="invitationCard"
+                        i18nKey="knockCard"
                         defaults="<bold>{{user}}</bold> wants to join <bold>{{name}}</bold>."
                         values={{ user: user, name: roomName }}
                         components={{ bold: <strong /> }}

--- a/pages/dashboard/index.js
+++ b/pages/dashboard/index.js
@@ -125,19 +125,18 @@ export default function Dashboard() {
                 <>
                     <h3>{ t('Accept Knocks') }</h3>
                     <br />
-                    { Array.from(pendingKnocks.values()).map((knock, index) => {
-                        return (
-                            <div key={knock.roomId}>
-                                { index > 0 && <><br /><hr /><br /></> }
-                                <KnockCard
-                                    roomId={knock.roomId}
-                                    roomName={knock.roomName}
-                                    user={knock.name}
-                                    userId={knock.userId}
-                                />
-                            </div>
-                        );
-                    }) }
+                    { [...pendingKnocks].map(([key, knock], index) => (
+                        <div key={key}>
+                            { index > 0 && <><br /><hr /><br /></> }
+                            <KnockCard
+                                roomId={knock.roomId}
+                                roomName={matrix.rooms.get(knock.roomId)?.name}
+                                userId={knock.userId}
+                                user={matrixClient.getUser(knock.userId).displayName}
+                                reason={knock.reason}
+                            />
+                        </div>
+                    )) }
                 </>
             }
 

--- a/public/locales/de/dashboard.json
+++ b/public/locales/de/dashboard.json
@@ -1,6 +1,7 @@
 {
   "invitationCard": "<bold>{{username}}</bold> hat dich zu <bold>{{service}}</bold> eingeladen.",
   "invitationCardHandled": "Du kannst dir nun <1><strong>{{roomName}}</strong></1> ansehen.",
+  "knockCard": "<bold>{{username}}</bold> möchte <bold>{{roomName}}</bold> betreten.",
   "You’ve declined the invitation.": "Du hast die Einladung abgelehnt.",
   "Direct Message": "Direktnachricht",
   "public": "öffentlich",


### PR DESCRIPTION
@aofn This is my suggestion on how to cleanly manage the internal state of pending knocks. It addresses the comments I've made on your other PR, mostly https://github.com/medienhaus/medienhaus-spaces/pull/114#discussion_r1417586543.
It also addresses what we've discussed in person / via chat.

I have also added the "reason" to `KnockCard`, which a user can provide when knocking:

<img width="803" alt="Screenshot 2023-12-07 at 17 21 30" src="https://github.com/medienhaus/medienhaus-spaces/assets/706419/f99a87f6-dd66-4a50-aa17-df8dff803bcb">


---

Feel free to ask questions in the diff; when you're happy you can just merge away.
As  you can see in the screenshot above, there's still some styling work that can be done when we have both: pending invitations **AND** pending knocks to manage. Maybe you can get to that within your own PR after this was merged.