### PR TITLE
Filter all `false` entries from the children array when building room objects

### DIFF
--- a/lib/Matrix.js
+++ b/lib/Matrix.js
@@ -49,7 +49,7 @@ function useMatrixProvider(auth) {
             roomId,
             name: room.name,
             meta: roomState.getStateEvents('dev.medienhaus.meta', '')?.getContent(),
-            children: roomState.getStateEvents('m.space.child').map(event => !_.isEmpty(event.getContent()) && event.getStateKey()),
+            children: roomState.getStateEvents('m.space.child').map(event => !_.isEmpty(event.getContent()) && event.getStateKey()).filter(child => child),
             notificationCount: room.getUnreadNotificationCount(),
             avatar,
         };


### PR DESCRIPTION
Currently the array, `children` which is returned by `buildRoomObject` inside `Matrix.js`,  sometimes returns `false` when the conditional inside map is not met. 
By filtering them we don't have to check for `false` children at later points inside the code.