### PR TITLE
/explore: conditional loading

### DIFF
--- a/pages/explore/[[...roomId]].js
+++ b/pages/explore/[[...roomId]].js
@@ -403,10 +403,10 @@ export default function Explore() {
                                         {table.getRowModel().rows?.length > 1 && (
                                             <Table>
                                                 {/*
-                                                      @NOTE: we cannot use border-top/-bottom for sticky thead (because borders scroll with the content);
-                                                      fortunately this does not apply to box-shadow, hence the madness below; we also increase the height
-                                                      from 48px (tailwind h-12 class in Table) to 50px, as the box-shadow is inset, else not shown on top
-                                                    */}
+                                                  @NOTE: we cannot use border-top/-bottom for sticky thead (because borders scroll with the content);
+                                                  fortunately this does not apply to box-shadow, hence the madness below; we also increase the height
+                                                  from 48px (tailwind h-12 class in Table) to 50px, as the box-shadow is inset, else not shown on top
+                                                */}
                                                 <TableHeader className="sticky top-0 h-[50px] bg-background shadow-[inset_0px_-1px_0px_0px_hsl(var(--muted-foreground)_/_0.2),inset_0px_1px_0px_0px_hsl(var(--muted-foreground)_/_0.2)]">
                                                     {table.getHeaderGroups().map((headerGroup) => (
                                                         <TableRow key={headerGroup.id}>
@@ -467,32 +467,32 @@ export default function Explore() {
                                         )}
 
                                         {/* @NOTE: pagination component which we are currently not using, but might in the future
-                                            {table.getRowModel().rows?.length > 1 && (
-                                                <div className="sticky bottom-0 flex w-full items-center space-x-2 border-t border-muted-foreground/20 bg-background py-4">
-                                                    <div className="flex-1 text-sm text-muted-foreground">
-                                                        Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
-                                                    </div>
-                                                    <div className="space-x-2">
-                                                        <Button
-                                                            variant="outline"
-                                                            size="sm"
-                                                            onClick={() => table.previousPage()}
-                                                            disabled={!table.getCanPreviousPage()}
-                                                        >
-                                                            Previous
-                                                        </Button>
-                                                        <Button
-                                                            variant="outline"
-                                                            size="sm"
-                                                            onClick={() => table.nextPage()}
-                                                            disabled={!table.getCanNextPage()}
-                                                        >
-                                                            Next
-                                                        </Button>
-                                                    </div>
+                                        {table.getRowModel().rows?.length > 1 && (
+                                            <div className="sticky bottom-0 flex w-full items-center space-x-2 border-t border-muted-foreground/20 bg-background py-4">
+                                                <div className="flex-1 text-sm text-muted-foreground">
+                                                    Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
                                                 </div>
-                                            )}
-                                            */}
+                                                <div className="space-x-2">
+                                                    <Button
+                                                        variant="outline"
+                                                        size="sm"
+                                                        onClick={() => table.previousPage()}
+                                                        disabled={!table.getCanPreviousPage()}
+                                                    >
+                                                        Previous
+                                                    </Button>
+                                                    <Button
+                                                        variant="outline"
+                                                        size="sm"
+                                                        onClick={() => table.nextPage()}
+                                                        disabled={!table.getCanNextPage()}
+                                                    >
+                                                        Next
+                                                    </Button>
+                                                </div>
+                                            </div>
+                                        )}
+                                        */}
                                     </>
                                 </TabsContent>
 

--- a/pages/explore/[[...roomId]].js
+++ b/pages/explore/[[...roomId]].js
@@ -278,7 +278,29 @@ export default function Explore() {
         getCoreRowModel: getCoreRowModel(),
     });
 
-    if (typeof window === 'undefined') return <LoadingSpinner />;
+    if (typeof window === 'undefined') {
+        return (
+            <DefaultLayout.LameColumn>
+                <LoadingSpinner className="!h-4 !w-4 !border-[2px]" />
+            </DefaultLayout.LameColumn>
+        );
+    }
+
+    if (isFetchingSpaceChildren) {
+        return (
+            <>
+                {progress !== 0 && (
+                    <div className="absolute left-0 top-0 w-full">
+                        <Progress value={progress} />
+                    </div>
+                )}
+
+                <DefaultLayout.LameColumn>
+                    <LoadingSpinner className="!h-[var(--icon-size)] !w-[var(--icon-size)] !border-[2px]" />
+                </DefaultLayout.LameColumn>
+            </>
+        );
+    }
 
     return (
         <>

--- a/pages/explore/[[...roomId]].js
+++ b/pages/explore/[[...roomId]].js
@@ -105,7 +105,7 @@ export default function Explore() {
         }).meta?.template;
 
     const canManageSpace = matrixClient.getRoom(roomId)?.currentState.hasSufficientPowerLevelFor('m.space.child', myPowerLevel);
-    const canAddMoreContent = canManageSpace && !isFetchingSpaceChildren;
+    const canAddMoreContent = matrixClient.getRoom(roomId)?.currentState.hasSufficientPowerLevelFor('m.space.child', myPowerLevel);
 
     // Redirect to the default room if no roomId is provided
     useEffect(() => {
@@ -178,6 +178,7 @@ export default function Explore() {
     };
 
     const data = selectedSpaceChildren[selectedSpaceChildren.length - 1];
+
     const columns = [
         {
             accessorKey: 'icon',
@@ -286,6 +287,7 @@ export default function Explore() {
                     <Progress value={progress} />
                 </div>
             )}
+
             {iframeRoomId ? (
                 <ExploreIframeViews
                     selectedSpaceChildren={selectedSpaceChildren}
@@ -355,6 +357,7 @@ export default function Explore() {
                                         </Icon>
                                         {isDesktop && t('Members')}
                                     </TabsTrigger>
+
                                     {canManageSpace && (
                                         <TabsTrigger
                                             onClick={() => {
@@ -372,15 +375,16 @@ export default function Explore() {
                                         </TabsTrigger>
                                     )}
                                 </TabsList>
+
                                 <TabsContent value="content">
                                     <>
                                         {table.getRowModel().rows?.length > 1 && (
                                             <Table>
                                                 {/*
-                                                  @NOTE: we cannot use border-top/-bottom for sticky thead (because borders scroll with the content);
-                                                  fortunately this does not apply to box-shadow, hence the madness below; we also increase the height
-                                                  from 48px (tailwind h-12 class in Table) to 50px, as the box-shadow is inset, else not shown on top
-                                                */}
+                                                      @NOTE: we cannot use border-top/-bottom for sticky thead (because borders scroll with the content);
+                                                      fortunately this does not apply to box-shadow, hence the madness below; we also increase the height
+                                                      from 48px (tailwind h-12 class in Table) to 50px, as the box-shadow is inset, else not shown on top
+                                                    */}
                                                 <TableHeader className="sticky top-0 h-[50px] bg-background shadow-[inset_0px_-1px_0px_0px_hsl(var(--muted-foreground)_/_0.2),inset_0px_1px_0px_0px_hsl(var(--muted-foreground)_/_0.2)]">
                                                     {table.getHeaderGroups().map((headerGroup) => (
                                                         <TableRow key={headerGroup.id}>
@@ -418,7 +422,7 @@ export default function Explore() {
                                             </Table>
                                         )}
 
-                                        {canAddMoreContent && progress === 0 && (
+                                        {canAddMoreContent && (
                                             <div className="sticky bottom-0 flex w-full items-center space-x-2 bg-background shadow-[0px_-1px_0px_0px_hsl(var(--muted-foreground)_/_0.2)]">
                                                 <QuickAddExplore
                                                     currentId={roomId}


### PR DESCRIPTION
Concerning the following issue from one of our evergrowing etherpads:

> description:
> in branch `explore`, header buttons and tab trigger buttons appear too soon
> 
> how to reproduce:
> navigate to `/explore`, then navigate to some sub-context which you moderate
> 
> problem:
> “new” header buttons and tab trigger buttons appear before “new” title and content are fetched/loaded; that means, the “new” header buttons and tab trigger buttons matching the context we navigated to, but title and content of old context (where we come from) are displayed for some time, which is quite intriguing.

The proposed maybe-workaround displays our loading spinner and progress bar with no content at all—no header buttons, no tab trigger buttons, no title, and no content—until we’re finished fetching the content to be displayed/rendered.

Unfortunately, some times—though not always—, right after making the navigation click to the new context, the tab trigger buttons briefly switch to a different state before nothing but the loading spinner and progress bar are being shown.

Maybe @robertschnuell you feel like debugging this, else we could merge and either deploy the old and rather intriguing behaviour, or the new and a little less intriguing behavior … 👀

<img width="1192" alt="Screenshot 2024-04-16 at 15 59 13" src="https://github.com/medienhaus/medienhaus-spaces/assets/63073125/7fc340a8-1cbf-4fef-9e9a-63520890f7c4">
