### PR TITLE
Reintroduce getIcon method to slim code in explore

### DIFF
--- a/pages/explore/[[...roomId]].js
+++ b/pages/explore/[[...roomId]].js
@@ -44,6 +44,21 @@ import ExploreMatrixActions from './manage-room/ExploreMatrixActions';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/UI/shadcn/Tabs';
 import { useMediaQuery } from '@/lib/utils';
 
+const getIcon = (template, type) => {
+    switch (template) {
+        case 'etherpad':
+            return <RiEditLine />;
+        case 'spacedeck':
+            return <RiBrush2Line />;
+        case 'tldraw':
+            return <RiBrushLine />;
+        case 'link':
+            return <RiLink />;
+        default:
+            return type === 'context' ? <RiFolderLine /> : <RiChat1Line />;
+    }
+};
+
 /**
  * Explore component for managing room hierarchies and content.
  *
@@ -187,55 +202,7 @@ export default function Explore() {
                 </Icon>
             ),
             cell: ({ row }) => {
-                /* @NOTE: the following conditions are copy-pasted from pages/explore/IframeSidebar.js */
-
-                if (row.original?.meta?.template === 'etherpad') {
-                    return (
-                        <Icon>
-                            <RiEditLine />
-                        </Icon>
-                    );
-                }
-
-                if (row.original?.meta?.template === 'spacedeck') {
-                    return (
-                        <Icon>
-                            <RiBrush2Line />
-                        </Icon>
-                    );
-                }
-
-                if (row.original?.meta?.template === 'tldraw') {
-                    return (
-                        <Icon>
-                            <RiBrushLine />
-                        </Icon>
-                    );
-                }
-
-                if (row.original?.meta?.template === 'link') {
-                    return (
-                        <Icon>
-                            <RiLink />
-                        </Icon>
-                    );
-                }
-
-                if (row.original?.meta?.type === 'context') {
-                    return (
-                        <Icon>
-                            <RiFolderLine />
-                        </Icon>
-                    );
-                }
-
-                if (!row.original?.meta) {
-                    return (
-                        <Icon>
-                            <RiChat1Line />
-                        </Icon>
-                    );
-                }
+                return <Icon>{getIcon(row.original?.meta?.template, row.original?.meta?.type)}</Icon>;
             },
         },
         {
@@ -341,7 +308,7 @@ export default function Explore() {
                                 myPowerLevel={myPowerLevel}
                                 setActiveContentView={setActiveContentView}
                                 joinRule={selectedSpaceChildren[selectedSpaceChildren.length - 1][0].join_rule}
-                        service="/explore"
+                                service="/explore"
                             />
 
                             <Tabs


### PR DESCRIPTION
Reintroducing the getIcon method which was removed in 5d366e55f6fd094abfe2c435663f3140261d8d4c and 5284563c7f56a6dfd6ddf3af226331a72c7221c3.  
This makes it easier to add new icons or move the function into its own file in case a lot of icons are added an the funfiton becomes very long.