### PR TITLE
Edit room name within explore

### DIFF
--- a/pages/explore/TreePath.js
+++ b/pages/explore/TreePath.js
@@ -11,7 +11,7 @@ import {
     BreadcrumbSeparator,
 } from '@/components/UI/shadcn/Breadcrumb';
 
-const TreePath = ({ selectedSpaceChildren }) => {
+const TreePath = ({ selectedSpaceChildren, roomName }) => {
     return (
         <>
             <Breadcrumb className="overflow-hidden">
@@ -36,7 +36,7 @@ const TreePath = ({ selectedSpaceChildren }) => {
                                                         asChild
                                                         className="grid w-full grid-flow-col justify-start gap-2"
                                                     >
-                                                        <Link href={`/explore/${roomId}`}>{path[0].name}</Link>
+                                                        <Link href={`/explore/${roomId}`}>{roomName || path[0].name}</Link>
                                                     </DropdownMenuItem>
                                                 );
                                             }
@@ -58,7 +58,7 @@ const TreePath = ({ selectedSpaceChildren }) => {
                                     <BreadcrumbItem className="inline overflow-hidden text-ellipsis whitespace-nowrap">
                                         <BreadcrumbLink asChild>
                                             <Link disabled href={`/explore/${roomId}`}>
-                                                {path[0].name}
+                                                {roomName || path[0].name}
                                             </Link>
                                         </BreadcrumbLink>
                                     </BreadcrumbItem>

--- a/pages/explore/[[...roomId]].js
+++ b/pages/explore/[[...roomId]].js
@@ -106,6 +106,8 @@ export default function Explore() {
 
     const canAddMoreContent = matrixClient.getRoom(roomId)?.currentState.hasSufficientPowerLevelFor('m.space.child', myPowerLevel);
 
+    const [roomName, setRoomName] = useState(selectedSpaceChildren?.[selectedSpaceChildren.length - 1]?.[0]?.name);
+
     // Redirect to the default room if no roomId is provided
     useEffect(() => {
         if (!roomId) {
@@ -318,7 +320,7 @@ export default function Explore() {
                     iframeRoomId={iframeRoomId}
                     breadcrumbs={
                         !_.isEmpty(selectedSpaceChildren) && (
-                            <TreePath selectedSpaceChildren={selectedSpaceChildren} iframeRoomId={iframeRoomId} />
+                            <TreePath selectedSpaceChildren={selectedSpaceChildren} iframeRoomId={iframeRoomId} roomName={roomName} />
                         )
                     }
                     title={name}
@@ -331,17 +333,21 @@ export default function Explore() {
                                 content={window.location.href}
                                 title={
                                     !_.isEmpty(selectedSpaceChildren) && (
-                                        <TreePath selectedSpaceChildren={selectedSpaceChildren} iframeRoomId={iframeRoomId} />
+                                        <TreePath
+                                            selectedSpaceChildren={selectedSpaceChildren}
+                                            iframeRoomId={iframeRoomId}
+                                            roomName={roomName}
+                                        />
                                     )
                                 }
-                                roomName={selectedSpaceChildren[selectedSpaceChildren.length - 1][0].name}
+                                roomName={roomName}
                                 removingLink={false}
                                 roomId={roomId}
                                 activeContentView={activeContentView}
                                 myPowerLevel={myPowerLevel}
                                 setActiveContentView={setActiveContentView}
                                 joinRule={selectedSpaceChildren[selectedSpaceChildren.length - 1][0].join_rule}
-                        service="/explore"
+                                service="/explore"
                             />
 
                             <Tabs
@@ -503,7 +509,7 @@ export default function Explore() {
                                 </TabsContent>
 
                                 <TabsContent value="settings">
-                                    <ExploreMatrixActions currentId={roomId} myPowerLevel={myPowerLevel} />
+                                    <ExploreMatrixActions currentId={roomId} myPowerLevel={myPowerLevel} setRoomName={setRoomName} />
                                 </TabsContent>
                             </Tabs>
                         </DefaultLayout.Wrapper>

--- a/pages/explore/manage-room/ChangeRoomName.js
+++ b/pages/explore/manage-room/ChangeRoomName.js
@@ -6,7 +6,7 @@ import { useAuth } from '@/lib/Auth';
 import ConfirmCancelButtons from '@/components/UI/ConfirmCancelButtons';
 import { Input } from '@/components/UI/shadcn/Input';
 
-const ChangeRoomName = ({ roomName, roomId }) => {
+const ChangeRoomName = ({ roomName, roomId, setRoomName }) => {
     const matrixClient = useAuth().getAuthenticationProvider('matrix').getMatrixClient();
     const [newRoomName, setNewRoomName] = useState('');
     const [isChangingName, setIsChangingName] = useState(false);
@@ -18,6 +18,7 @@ const ChangeRoomName = ({ roomName, roomId }) => {
 
         try {
             await matrixClient.setRoomName(roomId, newRoomName);
+            setRoomName(newRoomName);
             toast.success(
                 t('room name successfully changed to {{newRoomName}}. Please reload the page to see the changes.', { newRoomName }),
             );

--- a/pages/explore/manage-room/ChangeRoomName.js
+++ b/pages/explore/manage-room/ChangeRoomName.js
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+
+import { useAuth } from '@/lib/Auth';
+import ConfirmCancelButtons from '@/components/UI/ConfirmCancelButtons';
+import { Input } from '@/components/UI/shadcn/Input';
+
+const ChangeRoomName = ({ roomName, roomId }) => {
+    const matrixClient = useAuth().getAuthenticationProvider('matrix').getMatrixClient();
+    const [newRoomName, setNewRoomName] = useState('');
+    const [isChangingName, setIsChangingName] = useState(false);
+    const { t } = useTranslation('explore');
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setIsChangingName(true);
+
+        try {
+            await matrixClient.setRoomName(roomId, newRoomName);
+            toast.success(
+                t('room name successfully changed to {{newRoomName}}. Please reload the page to see the changes.', { newRoomName }),
+            );
+        } catch (error) {
+            toast.error(error.data?.error);
+        } finally {
+            setIsChangingName(false);
+        }
+    };
+
+    return (
+        <>
+            <form className="[&>*+*]:mt-4" onSubmit={handleSubmit} onReset={() => setNewRoomName(roomName)}>
+                <Input
+                    type="text"
+                    disabled={isChangingName}
+                    value={newRoomName || roomName}
+                    onChange={(e) => setNewRoomName(e.target.value)}
+                />
+                <ConfirmCancelButtons disabled={roomName === newRoomName} />
+            </form>
+        </>
+    );
+};
+
+export default ChangeRoomName;

--- a/pages/explore/manage-room/ExploreMatrixActions.js
+++ b/pages/explore/manage-room/ExploreMatrixActions.js
@@ -16,7 +16,7 @@ import ChangeRoomName from './ChangeRoomName';
  * @param {String} currentId - The ID of the current room.
  * @param {String} parentId - The ID of the parent of the currently observed room.
  * @param {Number} myPowerLevel - Number between 0 and 100.
- * @callback getSpaceChildren - A callback function.
+ * @param {Function} setRoomName - Function to set the room name.
  * @returns {JSX.Element} - The rendered component.
  */
 
@@ -65,6 +65,13 @@ const ExploreMatrixActions = ({ currentId, parentId, myPowerLevel, setRoomName }
                 */}
                 <TabsContent className="pb-6 [&>*+*]:mt-8" value="general">
                     <>
+                        {room.currentState.hasSufficientPowerLevelFor('m.room.title', myPowerLevel) && (
+                            <div className="[&>*+*]:mt-4">
+                                <h3>{t('Name')}</h3>
+                                <ChangeRoomName roomId={currentId} roomName={room.name} setRoomName={setRoomName} />
+                            </div>
+                        )}
+
                         {room.currentState.hasSufficientPowerLevelFor('m.room.topic', myPowerLevel) && (
                             <div className="[&>*+*]:mt-4">
                                 <h3>{t('Topic')}</h3>
@@ -76,13 +83,6 @@ const ExploreMatrixActions = ({ currentId, parentId, myPowerLevel, setRoomName }
                             <div className="[&>*+*]:mt-4">
                                 <h3>{t('Avatar')}</h3>
                                 <ChangeAvatar roomId={currentId} />
-                            </div>
-                        )}
-
-                        {room.currentState.hasSufficientPowerLevelFor('m.room.title', myPowerLevel) && (
-                            <div className="[&>*+*]:mt-4">
-                                <h3>{t('Name')}</h3>
-                                <ChangeRoomName roomId={currentId} roomName={room.name} setRoomName={setRoomName} />
                             </div>
                         )}
                     </>

--- a/pages/explore/manage-room/ExploreMatrixActions.js
+++ b/pages/explore/manage-room/ExploreMatrixActions.js
@@ -20,7 +20,7 @@ import ChangeRoomName from './ChangeRoomName';
  * @returns {JSX.Element} - The rendered component.
  */
 
-const ExploreMatrixActions = ({ currentId, parentId, myPowerLevel }) => {
+const ExploreMatrixActions = ({ currentId, parentId, myPowerLevel, setRoomName }) => {
     const { t } = useTranslation('explore');
 
     const matrixClient = useAuth().getAuthenticationProvider('matrix').getMatrixClient();
@@ -82,7 +82,7 @@ const ExploreMatrixActions = ({ currentId, parentId, myPowerLevel }) => {
                         {room.currentState.hasSufficientPowerLevelFor('m.room.title', myPowerLevel) && (
                             <div className="[&>*+*]:mt-4">
                                 <h3>{t('Name')}</h3>
-                                <ChangeRoomName roomId={currentId} roomName={room.name} />
+                                <ChangeRoomName roomId={currentId} roomName={room.name} setRoomName={setRoomName} />
                             </div>
                         )}
                     </>

--- a/pages/explore/manage-room/ExploreMatrixActions.js
+++ b/pages/explore/manage-room/ExploreMatrixActions.js
@@ -8,6 +8,7 @@ import ChangeAvatar from './ChangeAvatar';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/UI/shadcn/Tabs';
 import ChangeJoinRule from './ChangeJoinRule';
 import { useAuth } from '@/lib/Auth';
+import ChangeRoomName from './ChangeRoomName';
 
 /**
  * This component provides actions for managing contexts and items within a matrix room.
@@ -75,6 +76,13 @@ const ExploreMatrixActions = ({ currentId, parentId, myPowerLevel }) => {
                             <div className="[&>*+*]:mt-4">
                                 <h3>{t('Avatar')}</h3>
                                 <ChangeAvatar roomId={currentId} />
+                            </div>
+                        )}
+
+                        {room.currentState.hasSufficientPowerLevelFor('m.room.title', myPowerLevel) && (
+                            <div className="[&>*+*]:mt-4">
+                                <h3>{t('Name')}</h3>
+                                <ChangeRoomName roomId={currentId} roomName={room.name} />
                             </div>
                         )}
                     </>


### PR DESCRIPTION
Adds a component to explore settings to let users change the name of a space/room.

The room name in the header of explore is usually one step behind. This was a problem we encountered and weren't able to find the solution so far. Sometihing within `lib/Matrix.js` doesn't seem to fire when changing the name or is just one step behind.

users are therefore prompted to reload the page in order for changes to take (visual) effect